### PR TITLE
HL1: Add print action for menu orders in admin

### DIFF
--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1144,7 +1144,8 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
         .replace(/'/g, '&#39;');
 
     const orderNumber = escapeHtml(String(order.order_number || `#${order.id}`));
-    const restaurantName = escapeHtml(String(order.restaurant_name || 'Hafaloha'));
+    const locationRaw = String(order.location?.name || order.location_name || 'Restaurant');
+    const restaurantName = escapeHtml(locationRaw);
     const items = Array.isArray(order.items) ? order.items : [];
     const originalTotal = Number(order.total || 0);
     const totalRefunded = Number(order.total_refunded || 0);
@@ -1243,7 +1244,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     const contactName = escapeHtml(String(order.contact_name || 'N/A'));
     const contactPhone = escapeHtml(String(order.contact_phone || 'N/A'));
     const status = escapeHtml(String(order.status || 'pending'));
-    const locationName = escapeHtml(String(order.location?.name || order.location_name || 'Default'));
+    const locationName = escapeHtml(locationRaw);
     const orderSource = escapeHtml(String(order.staff_created ? 'Staff POS' : 'Online'));
 
     const latestPayment = Array.isArray(order.order_payments) && order.order_payments.length > 0
@@ -1284,8 +1285,10 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             .order-id { font-size: 14px; color: #4b5563; }
             .body { padding: 14px 16px; }
             .meta { font-size: 13px; line-height: 1.45; }
-            .meta-row { display: flex; justify-content: space-between; gap: 12px; margin: 2px 0; }
-            .meta-row strong { color: #111827; }
+            .meta-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 16px; margin-top: 2px; }
+            .meta-item { min-width: 0; }
+            .meta-label { font-size: 11px; text-transform: uppercase; letter-spacing: .45px; color: #6b7280; font-weight: 700; }
+            .meta-value { font-size: 15px; font-weight: 600; color: #111827; margin-top: 1px; overflow-wrap: anywhere; }
             .status-pill { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #f3f4f6; text-transform: uppercase; font-size: 11px; font-weight: 700; letter-spacing: .5px; }
             .divider { border: none; border-top: 1px dashed #cbd5e1; margin: 14px 0; }
             table { width: 100%; border-collapse: collapse; font-size: 13px; }
@@ -1334,10 +1337,44 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
 
             <div class="body">
               <div class="meta">
-                <div class="meta-row"><span><strong>Customer:</strong> ${contactName}</span><span class="status-pill">${status}</span></div>
-                <div class="meta-row"><span><strong>Phone:</strong> ${contactPhone}</span><span><strong>Source:</strong> ${orderSource}</span></div>
-                <div class="meta-row"><span><strong>Placed:</strong> ${placedTime}</span><span><strong>Pickup:</strong> ${pickupTime}</span></div>
-                <div class="meta-row"><span><strong>Location:</strong> ${locationName}</span><span><strong>Payment:</strong> ${paymentMethod} (${paymentStatus})</span></div>
+                <div class="meta-grid">
+                  <div class="meta-item">
+                    <div class="meta-label">Customer</div>
+                    <div class="meta-value">${contactName}</div>
+                  </div>
+                  <div class="meta-item">
+                    <div class="meta-label">Status</div>
+                    <div class="meta-value"><span class="status-pill">${status}</span></div>
+                  </div>
+
+                  <div class="meta-item">
+                    <div class="meta-label">Phone</div>
+                    <div class="meta-value">${contactPhone}</div>
+                  </div>
+                  <div class="meta-item">
+                    <div class="meta-label">Source</div>
+                    <div class="meta-value">${orderSource}</div>
+                  </div>
+
+                  <div class="meta-item">
+                    <div class="meta-label">Placed</div>
+                    <div class="meta-value">${placedTime}</div>
+                  </div>
+                  <div class="meta-item">
+                    <div class="meta-label">Pickup</div>
+                    <div class="meta-value">${pickupTime}</div>
+                  </div>
+
+                  <div class="meta-item">
+                    <div class="meta-label">Location</div>
+                    <div class="meta-value">${locationName}</div>
+                  </div>
+                  <div class="meta-item">
+                    <div class="meta-label">Payment</div>
+                    <div class="meta-value">${paymentMethod} (${paymentStatus})</div>
+                  </div>
+                </div>
+
                 ${specialInstructions}
 
                 <div class="kitchen-only checklist">
@@ -1392,6 +1429,10 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
               setMode(mode);
               setTimeout(function () { window.print(); }, 0);
             }
+
+            window.onafterprint = function () {
+              window.close();
+            };
 
             window.setMode = setMode;
             window.setModeAndPrint = setModeAndPrint;

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1284,22 +1284,38 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             .amount { text-align: right; white-space: nowrap; font-weight: 600; }
             .refund { display: flex; justify-content: space-between; font-size: 13px; color: #b91c1c; margin-bottom: 6px; }
             .total { display: flex; justify-content: space-between; font-size: 20px; font-weight: 800; margin-top: 2px; }
+            .copy-toggle { display: flex; gap: 8px; margin-top: 10px; }
+            .toggle-btn { flex: 1; border: 1px solid #d1d5db; border-radius: 8px; padding: 8px 10px; font-size: 12px; font-weight: 700; cursor: pointer; background: #fff; }
+            body.mode-kitchen .toggle-btn-kitchen,
+            body.mode-customer .toggle-btn-customer { background: #111827; color: #fff; border-color: #111827; }
+            .kitchen-only { display: none; }
+            .customer-only { display: none; }
+            body.mode-kitchen .kitchen-only { display: block; }
+            body.mode-customer .customer-only { display: block; }
+            .checklist { margin-top: 8px; padding: 8px; border: 1px dashed #cbd5e1; border-radius: 6px; font-size: 12px; }
+            .checklist-row { display: flex; justify-content: space-between; margin-top: 6px; }
+            .line { border-bottom: 1px solid #9ca3af; min-width: 120px; display: inline-block; height: 16px; }
             .actions { display: flex; gap: 8px; padding: 0 16px 14px; }
             .btn { flex: 1; border: none; border-radius: 8px; padding: 10px 12px; font-weight: 600; cursor: pointer; }
-            .btn-print { background: #111827; color: white; }
+            .btn-print-kitchen { background: #111827; color: white; }
+            .btn-print-customer { background: #374151; color: white; }
             .btn-close { background: #e5e7eb; color: #111827; }
             @media print {
               body { background: #fff; }
               .sheet { margin: 0; max-width: none; border: 0; border-radius: 0; box-shadow: none; }
-              .actions { display: none; }
+              .actions, .copy-toggle { display: none; }
             }
           </style>
         </head>
-        <body>
+        <body class="mode-kitchen">
           <div class="sheet">
             <div class="head">
               <div class="brand">${restaurantName}</div>
               <div class="order-id">Order ${orderNumber}</div>
+              <div class="copy-toggle">
+                <button class="toggle-btn toggle-btn-kitchen" onclick="setMode('kitchen')">Kitchen Preview</button>
+                <button class="toggle-btn toggle-btn-customer" onclick="setMode('customer')">Customer Preview</button>
+              </div>
             </div>
 
             <div class="body">
@@ -1309,6 +1325,19 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
                 <div class="meta-row"><span><strong>Placed:</strong> ${placedTime}</span><span><strong>Pickup:</strong> ${pickupTime}</span></div>
                 <div class="meta-row"><span><strong>Location:</strong> ${locationName}</span><span><strong>Payment:</strong> ${paymentMethod} (${paymentStatus})</span></div>
                 ${specialInstructions}
+
+                <div class="kitchen-only checklist">
+                  <strong>Kitchen Checklist</strong>
+                  <div class="checklist-row"><span>Packed by:</span><span class="line"></span></div>
+                  <div class="checklist-row"><span>Checked by:</span><span class="line"></span></div>
+                  <div class="checklist-row"><span>Ready at:</span><span class="line"></span></div>
+                </div>
+
+                <div class="customer-only checklist">
+                  <strong>Pickup Verification</strong>
+                  <div class="checklist-row"><span>Received by:</span><span class="line"></span></div>
+                  <div class="checklist-row"><span>Time:</span><span class="line"></span></div>
+                </div>
               </div>
 
               <hr class="divider" />
@@ -1334,9 +1363,25 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
 
             <div class="actions">
               <button class="btn btn-close" onclick="window.close()">Close</button>
-              <button class="btn btn-print" onclick="window.print()">Print</button>
+              <button class="btn btn-print-customer" onclick="setModeAndPrint('customer')">Print Customer Copy</button>
+              <button class="btn btn-print-kitchen" onclick="setModeAndPrint('kitchen')">Print Kitchen Copy</button>
             </div>
           </div>
+
+          <script>
+            function setMode(mode) {
+              document.body.classList.remove('mode-kitchen', 'mode-customer');
+              document.body.classList.add(mode === 'customer' ? 'mode-customer' : 'mode-kitchen');
+            }
+
+            function setModeAndPrint(mode) {
+              setMode(mode);
+              window.print();
+            }
+
+            window.setMode = setMode;
+            window.setModeAndPrint = setModeAndPrint;
+          </script>
         </body>
       </html>
     `);

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1165,7 +1165,13 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
               if (Array.isArray(item.customizations)) {
                 if (item.customizations.length === 0) return '';
                 return item.customizations
-                  .map((c: any) => `<div style="font-size:12px;color:#555;margin-top:2px;">• ${escapeHtml(String(c?.name || c))}</div>`)
+                  .map((c: any) => {
+                    const rendered =
+                      typeof c === 'object'
+                        ? (c?.name ?? c?.label ?? c?.value ?? JSON.stringify(c))
+                        : c;
+                    return `<div style="font-size:12px;color:#555;margin-top:2px;">• ${escapeHtml(String(rendered))}</div>`;
+                  })
                   .join('');
               }
 
@@ -1175,7 +1181,14 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
                 return entries
                   .map(([group, opts]: [string, any]) => {
                     const renderedOpts = Array.isArray(opts)
-                      ? opts.map((o: any) => escapeHtml(String(o))).join(', ')
+                      ? opts
+                          .map((o: any) => {
+                            if (typeof o === 'object') {
+                              return escapeHtml(String(o?.name ?? o?.label ?? o?.value ?? JSON.stringify(o)));
+                            }
+                            return escapeHtml(String(o));
+                          })
+                          .join(', ')
                       : escapeHtml(String(opts));
                     return `<div style="font-size:12px;color:#555;margin-top:2px;">${escapeHtml(group)}: ${renderedOpts}</div>`;
                   })

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1135,8 +1135,16 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
   }
 
   const handlePrintOrder = (order: any) => {
-    const orderNumber = order.order_number || `#${order.id}`;
-    const restaurantName = order.restaurant_name || 'Hafaloha';
+    const escapeHtml = (value: string) =>
+      value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+    const orderNumber = escapeHtml(String(order.order_number || `#${order.id}`));
+    const restaurantName = escapeHtml(String(order.restaurant_name || 'Hafaloha'));
     const items = Array.isArray(order.items) ? order.items : [];
     const total = Number(order.total || 0).toFixed(2);
 
@@ -1146,10 +1154,13 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             const qty = Number(item.quantity || 0);
             const price = Number(item.price || 0);
             const lineTotal = (qty * price).toFixed(2);
-            const note = item.notes ? `<div style="font-size:12px;color:#555;margin-top:2px;">Note: ${String(item.notes)}</div>` : '';
+            const itemName = escapeHtml(String(item.name || 'Item'));
+            const note = item.notes
+              ? `<div style="font-size:12px;color:#555;margin-top:2px;">Note: ${escapeHtml(String(item.notes))}</div>`
+              : '';
             return `
               <tr>
-                <td style="padding:8px 0;vertical-align:top;">${qty}x ${String(item.name || 'Item')}</td>
+                <td style="padding:8px 0;vertical-align:top;">${qty}x ${itemName}</td>
                 <td style="padding:8px 0;text-align:right;vertical-align:top;">$${lineTotal}</td>
               </tr>
               ${note ? `<tr><td colspan="2" style="padding:0 0 6px 0;">${note}</td></tr>` : ''}
@@ -1164,9 +1175,10 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
       return;
     }
 
-    const pickupTime = formatDate(order.pickup_time || order.created_at);
-    const contactName = order.contact_name || 'N/A';
-    const contactPhone = order.contact_phone || 'N/A';
+    const pickupTime = escapeHtml(String(formatDate(order.pickup_time || order.created_at)));
+    const contactName = escapeHtml(String(order.contact_name || 'N/A'));
+    const contactPhone = escapeHtml(String(order.contact_phone || 'N/A'));
+    const status = escapeHtml(String(order.status || 'pending'));
 
     printWindow.document.write(`
       <html>
@@ -1183,7 +1195,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             <div><strong>Customer:</strong> ${contactName}</div>
             <div><strong>Phone:</strong> ${contactPhone}</div>
             <div><strong>Pickup:</strong> ${pickupTime}</div>
-            <div><strong>Status:</strong> ${String(order.status || 'pending')}</div>
+            <div><strong>Status:</strong> ${status}</div>
           </div>
 
           <hr style="border:none;border-top:1px dashed #999;margin:10px 0;" />
@@ -1204,9 +1216,10 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
 
     printWindow.document.close();
     printWindow.focus();
-    setTimeout(() => {
+    printWindow.onload = () => {
       printWindow.print();
-    }, 250);
+      printWindow.onafterprint = () => printWindow.close();
+    };
   };
 
   // These functions are called directly in the JSX

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1146,7 +1146,10 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     const orderNumber = escapeHtml(String(order.order_number || `#${order.id}`));
     const restaurantName = escapeHtml(String(order.restaurant_name || 'Hafaloha'));
     const items = Array.isArray(order.items) ? order.items : [];
-    const total = Number(order.total || 0).toFixed(2);
+    const originalTotal = Number(order.total || 0);
+    const totalRefunded = Number(order.total_refunded || 0);
+    const netTotal = Math.max(0, originalTotal - totalRefunded).toFixed(2);
+    const total = netTotal;
 
     const itemsHtml = items.length
       ? items
@@ -1242,6 +1245,13 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
           </table>
 
           <hr style="border:none;border-top:1px dashed #999;margin:10px 0;" />
+
+          ${totalRefunded > 0 ? `
+            <div style="display:flex;justify-content:space-between;font-size:13px;color:#b91c1c;margin-bottom:4px;">
+              <span>Refunded</span>
+              <span>-$${totalRefunded.toFixed(2)}</span>
+            </div>
+          ` : ''}
 
           <div style="display:flex;justify-content:space-between;font-size:15px;font-weight:700;">
             <span>Total</span>

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1222,10 +1222,24 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
       return;
     }
 
-    const pickupTime = escapeHtml(
-      String((order.pickup_time || order.created_at) ? formatDate(order.pickup_time || order.created_at) : 'N/A')
-    );
-    const placedTime = escapeHtml(String(order.created_at ? formatDate(order.created_at) : 'N/A'));
+    const formatPrintDateTime = (dateString: string | null | undefined) => {
+      if (!dateString) return 'N/A';
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) return 'N/A';
+      return date.toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      });
+    };
+
+    const pickupTime = order.pickup_time
+      ? escapeHtml(String(formatPrintDateTime(order.pickup_time)))
+      : 'N/A';
+    const placedTime = escapeHtml(String(formatPrintDateTime(order.created_at)));
     const contactName = escapeHtml(String(order.contact_name || 'N/A'));
     const contactPhone = escapeHtml(String(order.contact_phone || 'N/A'));
     const status = escapeHtml(String(order.status || 'pending'));
@@ -1307,7 +1321,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             }
           </style>
         </head>
-        <body class="mode-kitchen">
+        <body class="mode-customer">
           <div class="sheet">
             <div class="head">
               <div class="brand">${restaurantName}</div>
@@ -1376,7 +1390,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
 
             function setModeAndPrint(mode) {
               setMode(mode);
-              window.print();
+              setTimeout(function () { window.print(); }, 0);
             }
 
             window.setMode = setMode;

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1159,8 +1159,8 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
       ? items
           .map((item: any) => {
             const qty = Number(item.quantity || 0);
-            const price = Number(item.price || 0);
-            const lineTotal = (qty * price).toFixed(2);
+            const price = item.price != null ? Number(item.price) : null;
+            const lineTotal = price != null ? (qty * price).toFixed(2) : null;
             const itemName = escapeHtml(String(item.name || 'Item'));
 
             const customizationsHtml = (() => {
@@ -1202,6 +1202,13 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
               return '';
             })();
 
+            const optionsHtml = (() => {
+              if (!Array.isArray(item.options) || item.options.length === 0) return '';
+              return item.options
+                .map((o: any) => `<div>• ${escapeHtml(String(o))}</div>`)
+                .join('');
+            })();
+
             const variantDetails = [item.size, item.color]
               .filter(Boolean)
               .map((v: any) => escapeHtml(String(v)))
@@ -1217,9 +1224,10 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
                   <div class="item-name">${qty}x ${itemName}</div>
                   ${variantDetails ? `<div class="item-meta">${variantDetails}</div>` : ''}
                   ${customizationsHtml ? `<div class="item-meta">${customizationsHtml}</div>` : ''}
+                  ${(!customizationsHtml && optionsHtml) ? `<div class="item-meta">${optionsHtml}</div>` : ''}
                   ${note ? `<div class="item-note"><strong>Note:</strong> ${note}</div>` : ''}
                 </td>
-                <td class="amount" style="padding:8px 0;vertical-align:top;">$${lineTotal}</td>
+                <td class="amount" style="padding:8px 0;vertical-align:top;">${lineTotal != null ? `$${lineTotal}` : '—'}</td>
               </tr>
             `;
           })

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1261,7 +1261,6 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     const contactName = escapeHtml(String(order.contact_name || 'N/A'));
     const contactPhone = escapeHtml(String(order.contact_phone || 'N/A'));
     const status = escapeHtml(String(order.status || 'pending'));
-    const locationName = escapeHtml(locationRaw);
     const orderSource = escapeHtml(String(order.staff_created ? 'Staff POS' : 'Online'));
 
     const latestPayment = Array.isArray(order.order_payments) && order.order_payments.length > 0
@@ -1286,7 +1285,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
       ? `<div style="margin-top:8px;padding:8px;background:#fffbeb;border:1px solid #fcd34d;border-radius:6px;"><strong>Special Instructions:</strong> ${escapeHtml(String(order.special_instructions))}</div>`
       : '';
 
-    const subtotalLine = order.subtotal != null
+    const subtotalLine = order.subtotal != null && Number(order.subtotal) > 0
       ? `<div class="breakdown-line"><span>Subtotal</span><span>$${Number(order.subtotal).toFixed(2)}</span></div>`
       : '';
     const taxLine = order.tax != null && Number(order.tax) > 0
@@ -1395,7 +1394,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
 
                   <div class="meta-item">
                     <div class="meta-label">Location</div>
-                    <div class="meta-value">${locationName}</div>
+                    <div class="meta-value">${restaurantName}</div>
                   </div>
                   <div class="meta-item">
                     <div class="meta-label">Payment</div>

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1155,15 +1155,46 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             const price = Number(item.price || 0);
             const lineTotal = (qty * price).toFixed(2);
             const itemName = escapeHtml(String(item.name || 'Item'));
+
+            const customizationsHtml = (() => {
+              if (!item.customizations) return '';
+
+              if (Array.isArray(item.customizations)) {
+                if (item.customizations.length === 0) return '';
+                return item.customizations
+                  .map((c: any) => `<div style="font-size:12px;color:#555;margin-top:2px;">• ${escapeHtml(String(c?.name || c))}</div>`)
+                  .join('');
+              }
+
+              if (typeof item.customizations === 'object') {
+                const entries = Object.entries(item.customizations);
+                if (entries.length === 0) return '';
+                return entries
+                  .map(([group, opts]: [string, any]) => {
+                    const renderedOpts = Array.isArray(opts)
+                      ? opts.map((o: any) => escapeHtml(String(o))).join(', ')
+                      : escapeHtml(String(opts));
+                    return `<div style="font-size:12px;color:#555;margin-top:2px;">${escapeHtml(group)}: ${renderedOpts}</div>`;
+                  })
+                  .join('');
+              }
+
+              return '';
+            })();
+
             const note = item.notes
               ? `<div style="font-size:12px;color:#555;margin-top:2px;">Note: ${escapeHtml(String(item.notes))}</div>`
               : '';
+
             return `
               <tr>
-                <td style="padding:8px 0;vertical-align:top;">${qty}x ${itemName}</td>
+                <td style="padding:8px 0;vertical-align:top;">
+                  <div>${qty}x ${itemName}</div>
+                  ${customizationsHtml}
+                  ${note}
+                </td>
                 <td style="padding:8px 0;text-align:right;vertical-align:top;">$${lineTotal}</td>
               </tr>
-              ${note ? `<tr><td colspan="2" style="padding:0 0 6px 0;">${note}</td></tr>` : ''}
             `;
           })
           .join('')
@@ -1179,10 +1210,15 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     const contactName = escapeHtml(String(order.contact_name || 'N/A'));
     const contactPhone = escapeHtml(String(order.contact_phone || 'N/A'));
     const status = escapeHtml(String(order.status || 'pending'));
+    const specialInstructions = order.special_instructions
+      ? `<div style="margin-top:6px;padding:6px;background:#fffbeb;border:1px solid #fcd34d;border-radius:4px;"><strong>Special Instructions:</strong> ${escapeHtml(String(order.special_instructions))}</div>`
+      : '';
 
     printWindow.document.write(`
+      <!DOCTYPE html>
       <html>
         <head>
+          <meta charset="utf-8" />
           <title>Order ${orderNumber}</title>
         </head>
         <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; margin: 16px; color: #111;">
@@ -1196,6 +1232,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             <div><strong>Phone:</strong> ${contactPhone}</div>
             <div><strong>Pickup:</strong> ${pickupTime}</div>
             <div><strong>Status:</strong> ${status}</div>
+            ${specialInstructions}
           </div>
 
           <hr style="border:none;border-top:1px dashed #999;margin:10px 0;" />

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1263,9 +1263,14 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     const status = escapeHtml(String(order.status || 'pending'));
     const orderSource = escapeHtml(String(order.staff_created ? 'Staff POS' : 'Online'));
 
-    const latestPayment = Array.isArray(order.order_payments) && order.order_payments.length > 0
-      ? order.order_payments[order.order_payments.length - 1]
-      : null;
+    const latestPayment = (() => {
+      if (!Array.isArray(order.order_payments) || order.order_payments.length === 0) return null;
+      return [...order.order_payments].sort((a: any, b: any) => {
+        const aTime = new Date(a?.created_at ?? 0).getTime();
+        const bTime = new Date(b?.created_at ?? 0).getTime();
+        return bTime - aTime;
+      })[0];
+    })();
 
     const paymentMethod = escapeHtml(
       String(order.payment_method || latestPayment?.payment_method || (order.staff_created ? 'In-Store' : 'Online'))

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1357,7 +1357,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
               <div class="brand">${restaurantName}</div>
               <div class="order-id">Order ${orderNumber}</div>
               <div class="copy-toggle">
-                <button class="toggle-btn toggle-btn-kitchen" onclick="setMode('kitchen')">Kitchen Preview</button>
+                <button class="toggle-btn toggle-btn-kitchen" onclick="setMode('kitchen')">FOH Preview</button>
                 <button class="toggle-btn toggle-btn-customer" onclick="setMode('customer')">Customer Preview</button>
               </div>
             </div>
@@ -1405,7 +1405,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
                 ${specialInstructions}
 
                 <div class="kitchen-only checklist">
-                  <strong>Kitchen Checklist</strong>
+                  <strong>FOH Checklist</strong>
                   <div class="checklist-row"><span>Packed by:</span><span class="line"></span></div>
                   <div class="checklist-row"><span>Checked by:</span><span class="line"></span></div>
                   <div class="checklist-row"><span>Ready at:</span><span class="line"></span></div>
@@ -1446,7 +1446,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             <div class="actions">
               <button class="btn btn-close" onclick="window.close()">Close</button>
               <button class="btn btn-print-customer" onclick="setModeAndPrint('customer')">Print Customer Copy</button>
-              <button class="btn btn-print-kitchen" onclick="setModeAndPrint('kitchen')">Print Kitchen Copy</button>
+              <button class="btn btn-print-kitchen" onclick="setModeAndPrint('kitchen')">Print FOH Copy</button>
             </div>
           </div>
 

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1214,12 +1214,12 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
       </html>
     `);
 
-    printWindow.document.close();
-    printWindow.focus();
     printWindow.onload = () => {
       printWindow.print();
       printWindow.onafterprint = () => printWindow.close();
     };
+    printWindow.document.close();
+    printWindow.focus();
   };
 
   // These functions are called directly in the JSX

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1239,12 +1239,19 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     const paymentMethod = escapeHtml(
       String(order.payment_method || latestPayment?.payment_method || (order.staff_created ? 'In-Store' : 'Online'))
     );
+    const inferredPaymentStatus =
+      order.status === 'refunded'
+        ? 'refunded'
+        : order.status === 'pending'
+          ? 'pending'
+          : 'unknown';
+
     const paymentStatus = escapeHtml(
-      String(order.payment_status || latestPayment?.status || (order.status === 'refunded' ? 'refunded' : 'paid'))
+      String(order.payment_status || latestPayment?.status || inferredPaymentStatus)
     );
 
     const specialInstructions = order.special_instructions
-      ? `<div style="margin-top:6px;padding:6px;background:#fffbeb;border:1px solid #fcd34d;border-radius:4px;"><strong>Special Instructions:</strong> ${escapeHtml(String(order.special_instructions))}</div>`
+      ? `<div style="margin-top:8px;padding:8px;background:#fffbeb;border:1px solid #fcd34d;border-radius:6px;"><strong>Special Instructions:</strong> ${escapeHtml(String(order.special_instructions))}</div>`
       : '';
 
     printWindow.document.write(`
@@ -1252,53 +1259,83 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
       <html>
         <head>
           <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <title>Order ${orderNumber}</title>
+          <style>
+            :root { color-scheme: light; }
+            body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; margin: 0; background: #f8fafc; color: #111827; }
+            .sheet { max-width: 420px; margin: 16px auto; background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 4px 12px rgba(0,0,0,0.08); overflow: hidden; }
+            .head { padding: 14px 16px; border-bottom: 1px solid #e5e7eb; text-align: center; }
+            .brand { font-size: 26px; font-weight: 800; letter-spacing: .2px; margin-bottom: 2px; }
+            .order-id { font-size: 14px; color: #4b5563; }
+            .body { padding: 14px 16px; }
+            .meta { font-size: 13px; line-height: 1.45; }
+            .meta-row { display: flex; justify-content: space-between; gap: 12px; margin: 2px 0; }
+            .meta-row strong { color: #111827; }
+            .status-pill { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #f3f4f6; text-transform: uppercase; font-size: 11px; font-weight: 700; letter-spacing: .5px; }
+            .divider { border: none; border-top: 1px dashed #cbd5e1; margin: 12px 0; }
+            table { width: 100%; border-collapse: collapse; font-size: 13px; }
+            td { padding: 8px 0; vertical-align: top; }
+            .amount { text-align: right; white-space: nowrap; }
+            .refund { display: flex; justify-content: space-between; font-size: 13px; color: #b91c1c; margin-bottom: 6px; }
+            .total { display: flex; justify-content: space-between; font-size: 20px; font-weight: 800; margin-top: 2px; }
+            .actions { display: flex; gap: 8px; padding: 0 16px 14px; }
+            .btn { flex: 1; border: none; border-radius: 8px; padding: 10px 12px; font-weight: 600; cursor: pointer; }
+            .btn-print { background: #111827; color: white; }
+            .btn-close { background: #e5e7eb; color: #111827; }
+            @media print {
+              body { background: #fff; }
+              .sheet { margin: 0; max-width: none; border: 0; border-radius: 0; box-shadow: none; }
+              .actions { display: none; }
+            }
+          </style>
         </head>
-        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; margin: 16px; color: #111;">
-          <div style="text-align:center;margin-bottom:14px;">
-            <div style="font-size:18px;font-weight:700;">${restaurantName}</div>
-            <div style="font-size:14px;">Order ${orderNumber}</div>
-          </div>
-
-          <div style="font-size:13px; margin-bottom:10px;">
-            <div><strong>Customer:</strong> ${contactName}</div>
-            <div><strong>Phone:</strong> ${contactPhone}</div>
-            <div><strong>Placed:</strong> ${placedTime}</div>
-            <div><strong>Pickup:</strong> ${pickupTime}</div>
-            <div><strong>Status:</strong> ${status}</div>
-            <div><strong>Source:</strong> ${orderSource}</div>
-            <div><strong>Location:</strong> ${locationName}</div>
-            <div><strong>Payment:</strong> ${paymentMethod} (${paymentStatus})</div>
-            ${specialInstructions}
-          </div>
-
-          <hr style="border:none;border-top:1px dashed #999;margin:10px 0;" />
-
-          <table style="width:100%;border-collapse:collapse;font-size:13px;">
-            ${itemsHtml}
-          </table>
-
-          <hr style="border:none;border-top:1px dashed #999;margin:10px 0;" />
-
-          ${totalRefunded > 0 ? `
-            <div style="display:flex;justify-content:space-between;font-size:13px;color:#b91c1c;margin-bottom:4px;">
-              <span>Refunded</span>
-              <span>-$${totalRefunded.toFixed(2)}</span>
+        <body>
+          <div class="sheet">
+            <div class="head">
+              <div class="brand">${restaurantName}</div>
+              <div class="order-id">Order ${orderNumber}</div>
             </div>
-          ` : ''}
 
-          <div style="display:flex;justify-content:space-between;font-size:15px;font-weight:700;">
-            <span>Total</span>
-            <span>$${total}</span>
+            <div class="body">
+              <div class="meta">
+                <div class="meta-row"><span><strong>Customer:</strong> ${contactName}</span><span class="status-pill">${status}</span></div>
+                <div class="meta-row"><span><strong>Phone:</strong> ${contactPhone}</span><span><strong>Source:</strong> ${orderSource}</span></div>
+                <div class="meta-row"><span><strong>Placed:</strong> ${placedTime}</span><span><strong>Pickup:</strong> ${pickupTime}</span></div>
+                <div class="meta-row"><span><strong>Location:</strong> ${locationName}</span><span><strong>Payment:</strong> ${paymentMethod} (${paymentStatus})</span></div>
+                ${specialInstructions}
+              </div>
+
+              <hr class="divider" />
+
+              <table>
+                ${itemsHtml}
+              </table>
+
+              <hr class="divider" />
+
+              ${totalRefunded > 0 ? `
+                <div class="refund">
+                  <span>Refunded</span>
+                  <span>-$${totalRefunded.toFixed(2)}</span>
+                </div>
+              ` : ''}
+
+              <div class="total">
+                <span>Total</span>
+                <span>$${total}</span>
+              </div>
+            </div>
+
+            <div class="actions">
+              <button class="btn btn-close" onclick="window.close()">Close</button>
+              <button class="btn btn-print" onclick="window.print()">Print</button>
+            </div>
           </div>
         </body>
       </html>
     `);
 
-    printWindow.onload = () => {
-      printWindow.print();
-      printWindow.onafterprint = () => printWindow.close();
-    };
     printWindow.document.close();
     printWindow.focus();
   };

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1261,8 +1261,8 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     const latestPayment = (() => {
       if (!Array.isArray(order.order_payments) || order.order_payments.length === 0) return null;
       return [...order.order_payments].sort((a: any, b: any) => {
-        const aTime = new Date(a?.created_at ?? 0).getTime();
-        const bTime = new Date(b?.created_at ?? 0).getTime();
+        const aTime = a?.created_at ? (new Date(a.created_at).getTime() || 0) : 0;
+        const bTime = b?.created_at ? (new Date(b.created_at).getTime() || 0) : 0;
         return bTime - aTime;
       })[0];
     })();

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1458,12 +1458,14 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
 
             function setModeAndPrint(mode) {
               setMode(mode);
-              setTimeout(function () { window.print(); }, 0);
+              setTimeout(function () {
+                window.onafterprint = function () {
+                  window.onafterprint = null;
+                  window.close();
+                };
+                window.print();
+              }, 0);
             }
-
-            window.onafterprint = function () {
-              window.close();
-            };
 
             window.setMode = setMode;
             window.setModeAndPrint = setModeAndPrint;

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1170,7 +1170,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
                       typeof c === 'object'
                         ? (c?.name ?? c?.label ?? c?.value ?? JSON.stringify(c))
                         : c;
-                    return `<div style="font-size:12px;color:#555;margin-top:2px;">• ${escapeHtml(String(rendered))}</div>`;
+                    return `<div>• ${escapeHtml(String(rendered))}</div>`;
                   })
                   .join('');
               }
@@ -1190,7 +1190,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
                           })
                           .join(', ')
                       : escapeHtml(String(opts));
-                    return `<div style="font-size:12px;color:#555;margin-top:2px;">${escapeHtml(group)}: ${renderedOpts}</div>`;
+                    return `<div>${escapeHtml(group)}: ${renderedOpts}</div>`;
                   })
                   .join('');
               }
@@ -1199,17 +1199,17 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             })();
 
             const note = item.notes
-              ? `<div style="font-size:12px;color:#555;margin-top:2px;">Note: ${escapeHtml(String(item.notes))}</div>`
+              ? escapeHtml(String(item.notes))
               : '';
 
             return `
-              <tr>
+              <tr class="item-row">
                 <td style="padding:8px 0;vertical-align:top;">
-                  <div>${qty}x ${itemName}</div>
-                  ${customizationsHtml}
-                  ${note}
+                  <div class="item-name">${qty}x ${itemName}</div>
+                  ${customizationsHtml ? `<div class="item-meta">${customizationsHtml}</div>` : ''}
+                  ${note ? `<div class="item-note"><strong>Note:</strong> ${note}</div>` : ''}
                 </td>
-                <td style="padding:8px 0;text-align:right;vertical-align:top;">$${lineTotal}</td>
+                <td class="amount" style="padding:8px 0;vertical-align:top;">$${lineTotal}</td>
               </tr>
             `;
           })
@@ -1273,10 +1273,15 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             .meta-row { display: flex; justify-content: space-between; gap: 12px; margin: 2px 0; }
             .meta-row strong { color: #111827; }
             .status-pill { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #f3f4f6; text-transform: uppercase; font-size: 11px; font-weight: 700; letter-spacing: .5px; }
-            .divider { border: none; border-top: 1px dashed #cbd5e1; margin: 12px 0; }
+            .divider { border: none; border-top: 1px dashed #cbd5e1; margin: 14px 0; }
             table { width: 100%; border-collapse: collapse; font-size: 13px; }
+            tr.item-row td { padding: 10px 0; border-bottom: 1px dashed #e5e7eb; }
+            tr.item-row:last-of-type td { border-bottom: 0; }
             td { padding: 8px 0; vertical-align: top; }
-            .amount { text-align: right; white-space: nowrap; }
+            .item-name { font-size: 14px; font-weight: 700; color: #111827; }
+            .item-meta { font-size: 12px; color: #374151; margin-top: 3px; padding-left: 8px; border-left: 2px solid #d1d5db; }
+            .item-note { font-size: 12px; color: #1f2937; margin-top: 4px; padding: 4px 6px; background: #f9fafb; border-radius: 4px; }
+            .amount { text-align: right; white-space: nowrap; font-weight: 600; }
             .refund { display: flex; justify-content: space-between; font-size: 13px; color: #b91c1c; margin-bottom: 6px; }
             .total { display: flex; justify-content: space-between; font-size: 20px; font-weight: 800; margin-top: 2px; }
             .actions { display: flex; gap: 8px; padding: 0 16px 14px; }

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1202,6 +1202,11 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
               return '';
             })();
 
+            const variantDetails = [item.size, item.color]
+              .filter(Boolean)
+              .map((v: any) => escapeHtml(String(v)))
+              .join(' / ');
+
             const note = item.notes
               ? escapeHtml(String(item.notes))
               : '';
@@ -1210,6 +1215,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
               <tr class="item-row">
                 <td style="padding:8px 0;vertical-align:top;">
                   <div class="item-name">${qty}x ${itemName}</div>
+                  ${variantDetails ? `<div class="item-meta">${variantDetails}</div>` : ''}
                   ${customizationsHtml ? `<div class="item-meta">${customizationsHtml}</div>` : ''}
                   ${note ? `<div class="item-note"><strong>Note:</strong> ${note}</div>` : ''}
                 </td>
@@ -1272,6 +1278,16 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
       ? `<div style="margin-top:8px;padding:8px;background:#fffbeb;border:1px solid #fcd34d;border-radius:6px;"><strong>Special Instructions:</strong> ${escapeHtml(String(order.special_instructions))}</div>`
       : '';
 
+    const subtotalLine = order.subtotal != null
+      ? `<div class="breakdown-line"><span>Subtotal</span><span>$${Number(order.subtotal).toFixed(2)}</span></div>`
+      : '';
+    const taxLine = order.tax != null && Number(order.tax) > 0
+      ? `<div class="breakdown-line"><span>Tax</span><span>$${Number(order.tax).toFixed(2)}</span></div>`
+      : '';
+    const tipLine = order.tip != null && Number(order.tip) > 0
+      ? `<div class="breakdown-line"><span>Tip</span><span>$${Number(order.tip).toFixed(2)}</span></div>`
+      : '';
+
     printWindow.document.write(`
       <!DOCTYPE html>
       <html>
@@ -1285,7 +1301,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             .sheet { max-width: 420px; margin: 16px auto; background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 4px 12px rgba(0,0,0,0.08); overflow: hidden; }
             .head { padding: 14px 16px; border-bottom: 1px solid #e5e7eb; text-align: center; }
             .brand { font-size: 26px; font-weight: 800; letter-spacing: .2px; margin-bottom: 2px; }
-            .order-id { font-size: 14px; color: #4b5563; }
+            .order-id { font-size: 15px; color: #0f172a; font-weight: 800; letter-spacing: .25px; }
             .body { padding: 14px 16px; }
             .meta { font-size: 13px; line-height: 1.45; }
             .meta-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 16px; margin-top: 2px; }
@@ -1302,8 +1318,9 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             .item-meta { font-size: 12px; color: #374151; margin-top: 3px; padding-left: 8px; border-left: 2px solid #d1d5db; }
             .item-note { font-size: 12px; color: #1f2937; margin-top: 4px; padding: 4px 6px; background: #f9fafb; border-radius: 4px; }
             .amount { text-align: right; white-space: nowrap; font-weight: 600; }
+            .breakdown-line { display: flex; justify-content: space-between; font-size: 13px; color: #374151; margin-bottom: 4px; }
             .refund { display: flex; justify-content: space-between; font-size: 13px; color: #b91c1c; margin-bottom: 6px; }
-            .total { display: flex; justify-content: space-between; font-size: 20px; font-weight: 800; margin-top: 2px; }
+            .total { display: flex; justify-content: space-between; font-size: 20px; font-weight: 800; margin-top: 4px; }
             .copy-toggle { display: flex; gap: 8px; margin-top: 10px; }
             .toggle-btn { flex: 1; border: 1px solid #d1d5db; border-radius: 8px; padding: 8px 10px; font-size: 12px; font-weight: 700; cursor: pointer; background: #fff; }
             body.mode-kitchen .toggle-btn-kitchen,
@@ -1401,6 +1418,10 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
               </table>
 
               <hr class="divider" />
+
+              ${subtotalLine}
+              ${taxLine}
+              ${tipLine}
 
               ${totalRefunded > 0 ? `
                 <div class="refund">

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1135,7 +1135,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     setEditingOrder(null);
   }
 
-  const handlePrintOrder = (order: Order) => {
+  const handlePrintOrder = useCallback((order: Order) => {
     const escapeHtml = (value: string) =>
       value
         .replace(/&/g, '&amp;')
@@ -1483,7 +1483,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     printWindow.document.write(receiptHtml);
     printWindow.document.close();
     printWindow.focus();
-  };
+  }, []);
 
   // These functions are called directly in the JSX
 

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -21,6 +21,7 @@ import { orderPaymentsApi } from '../../../shared/api/endpoints/orderPayments';
 import { orderPaymentOperationsApi } from '../../../shared/api/endpoints/orderPaymentOperations';
 import { api } from '../../../shared/api';
 import toastUtils from '../../../shared/utils/toastUtils';
+import type { Order } from '../../types/order';
 
 type OrderStatus = 'pending' | 'preparing' | 'ready' | 'completed' | 'cancelled' | 'confirmed' | 'refunded';
 
@@ -1134,7 +1135,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     setEditingOrder(null);
   }
 
-  const handlePrintOrder = (order: any) => {
+  const handlePrintOrder = (order: Order) => {
     const escapeHtml = (value: string) =>
       value
         .replace(/&/g, '&amp;')
@@ -1234,12 +1235,6 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
           .join('')
       : '<tr><td colspan="2" style="padding:8px 0;color:#666;">No items found</td></tr>';
 
-    const printWindow = window.open('', '_blank', 'width=420,height=700');
-    if (!printWindow) {
-      toastUtils.error('Could not open print window. Please allow popups and try again.');
-      return;
-    }
-
     const formatPrintDateTime = (dateString: string | null | undefined) => {
       if (!dateString) return 'N/A';
       const date = new Date(dateString);
@@ -1300,7 +1295,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
       ? `<div class="breakdown-line"><span>Tip</span><span>$${Number(order.tip).toFixed(2)}</span></div>`
       : '';
 
-    printWindow.document.write(`
+    const receiptHtml = `
       <!DOCTYPE html>
       <html>
         <head>
@@ -1475,8 +1470,15 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
           </script>
         </body>
       </html>
-    `);
+    `;
 
+    const printWindow = window.open('', '_blank', 'width=420,height=700');
+    if (!printWindow) {
+      toastUtils.error('Could not open print window. Please allow popups and try again.');
+      return;
+    }
+
+    printWindow.document.write(receiptHtml);
     printWindow.document.close();
     printWindow.focus();
   };

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1225,9 +1225,24 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     const pickupTime = escapeHtml(
       String((order.pickup_time || order.created_at) ? formatDate(order.pickup_time || order.created_at) : 'N/A')
     );
+    const placedTime = escapeHtml(String(order.created_at ? formatDate(order.created_at) : 'N/A'));
     const contactName = escapeHtml(String(order.contact_name || 'N/A'));
     const contactPhone = escapeHtml(String(order.contact_phone || 'N/A'));
     const status = escapeHtml(String(order.status || 'pending'));
+    const locationName = escapeHtml(String(order.location?.name || order.location_name || 'Default'));
+    const orderSource = escapeHtml(String(order.staff_created ? 'Staff POS' : 'Online'));
+
+    const latestPayment = Array.isArray(order.order_payments) && order.order_payments.length > 0
+      ? order.order_payments[order.order_payments.length - 1]
+      : null;
+
+    const paymentMethod = escapeHtml(
+      String(order.payment_method || latestPayment?.payment_method || (order.staff_created ? 'In-Store' : 'Online'))
+    );
+    const paymentStatus = escapeHtml(
+      String(order.payment_status || latestPayment?.status || (order.status === 'refunded' ? 'refunded' : 'paid'))
+    );
+
     const specialInstructions = order.special_instructions
       ? `<div style="margin-top:6px;padding:6px;background:#fffbeb;border:1px solid #fcd34d;border-radius:4px;"><strong>Special Instructions:</strong> ${escapeHtml(String(order.special_instructions))}</div>`
       : '';
@@ -1248,8 +1263,12 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
           <div style="font-size:13px; margin-bottom:10px;">
             <div><strong>Customer:</strong> ${contactName}</div>
             <div><strong>Phone:</strong> ${contactPhone}</div>
+            <div><strong>Placed:</strong> ${placedTime}</div>
             <div><strong>Pickup:</strong> ${pickupTime}</div>
             <div><strong>Status:</strong> ${status}</div>
+            <div><strong>Source:</strong> ${orderSource}</div>
+            <div><strong>Location:</strong> ${locationName}</div>
+            <div><strong>Payment:</strong> ${paymentMethod} (${paymentStatus})</div>
             ${specialInstructions}
           </div>
 

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1222,7 +1222,9 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
       return;
     }
 
-    const pickupTime = escapeHtml(String(formatDate(order.pickup_time || order.created_at)));
+    const pickupTime = escapeHtml(
+      String((order.pickup_time || order.created_at) ? formatDate(order.pickup_time || order.created_at) : 'N/A')
+    );
     const contactName = escapeHtml(String(order.contact_name || 'N/A'));
     const contactPhone = escapeHtml(String(order.contact_phone || 'N/A'));
     const status = escapeHtml(String(order.status || 'pending'));

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1134,6 +1134,81 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     setEditingOrder(null);
   }
 
+  const handlePrintOrder = (order: any) => {
+    const orderNumber = order.order_number || `#${order.id}`;
+    const restaurantName = order.restaurant_name || 'Hafaloha';
+    const items = Array.isArray(order.items) ? order.items : [];
+    const total = Number(order.total || 0).toFixed(2);
+
+    const itemsHtml = items.length
+      ? items
+          .map((item: any) => {
+            const qty = Number(item.quantity || 0);
+            const price = Number(item.price || 0);
+            const lineTotal = (qty * price).toFixed(2);
+            const note = item.notes ? `<div style="font-size:12px;color:#555;margin-top:2px;">Note: ${String(item.notes)}</div>` : '';
+            return `
+              <tr>
+                <td style="padding:8px 0;vertical-align:top;">${qty}x ${String(item.name || 'Item')}</td>
+                <td style="padding:8px 0;text-align:right;vertical-align:top;">$${lineTotal}</td>
+              </tr>
+              ${note ? `<tr><td colspan="2" style="padding:0 0 6px 0;">${note}</td></tr>` : ''}
+            `;
+          })
+          .join('')
+      : '<tr><td colspan="2" style="padding:8px 0;color:#666;">No items found</td></tr>';
+
+    const printWindow = window.open('', '_blank', 'width=420,height=700');
+    if (!printWindow) {
+      toastUtils.error('Could not open print window. Please allow popups and try again.');
+      return;
+    }
+
+    const pickupTime = formatDate(order.pickup_time || order.created_at);
+    const contactName = order.contact_name || 'N/A';
+    const contactPhone = order.contact_phone || 'N/A';
+
+    printWindow.document.write(`
+      <html>
+        <head>
+          <title>Order ${orderNumber}</title>
+        </head>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; margin: 16px; color: #111;">
+          <div style="text-align:center;margin-bottom:14px;">
+            <div style="font-size:18px;font-weight:700;">${restaurantName}</div>
+            <div style="font-size:14px;">Order ${orderNumber}</div>
+          </div>
+
+          <div style="font-size:13px; margin-bottom:10px;">
+            <div><strong>Customer:</strong> ${contactName}</div>
+            <div><strong>Phone:</strong> ${contactPhone}</div>
+            <div><strong>Pickup:</strong> ${pickupTime}</div>
+            <div><strong>Status:</strong> ${String(order.status || 'pending')}</div>
+          </div>
+
+          <hr style="border:none;border-top:1px dashed #999;margin:10px 0;" />
+
+          <table style="width:100%;border-collapse:collapse;font-size:13px;">
+            ${itemsHtml}
+          </table>
+
+          <hr style="border:none;border-top:1px dashed #999;margin:10px 0;" />
+
+          <div style="display:flex;justify-content:space-between;font-size:15px;font-weight:700;">
+            <span>Total</span>
+            <span>$${total}</span>
+          </div>
+        </body>
+      </html>
+    `);
+
+    printWindow.document.close();
+    printWindow.focus();
+    setTimeout(() => {
+      printWindow.print();
+    }, 250);
+  };
+
   // These functions are called directly in the JSX
 
   // Single-order action buttons for CollapsibleOrderCard
@@ -1308,6 +1383,21 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             </>
           )}
           
+          {/* Print button - always available */}
+          <button
+            className="p-2 text-gray-400 hover:text-gray-600 rounded-md"
+            onClick={() => handlePrintOrder(order)}
+            aria-label="Print order"
+            title="Print order"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none"
+                viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6v-8z"
+              />
+            </svg>
+          </button>
+
           {/* Edit button - always available */}
           <button
             className="p-2 text-gray-400 hover:text-gray-600 rounded-md"

--- a/src/ordering/components/admin/OrderManager.tsx
+++ b/src/ordering/components/admin/OrderManager.tsx
@@ -1146,7 +1146,10 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
     const orderNumber = escapeHtml(String(order.order_number || `#${order.id}`));
     const locationRaw = String(order.location?.name || order.location_name || 'Restaurant');
     const restaurantName = escapeHtml(locationRaw);
-    const items = Array.isArray(order.items) ? order.items : [];
+    const items = [
+      ...(Array.isArray(order.items) ? order.items : []),
+      ...(Array.isArray(order.merchandise_items) ? order.merchandise_items : []),
+    ];
     const originalTotal = Number(order.total || 0);
     const totalRefunded = Number(order.total_refunded || 0);
     const netTotal = Math.max(0, originalTotal - totalRefunded).toFixed(2);
@@ -1309,9 +1312,9 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
             .customer-only { display: none; }
             body.mode-kitchen .kitchen-only { display: block; }
             body.mode-customer .customer-only { display: block; }
-            .checklist { margin-top: 8px; padding: 8px; border: 1px dashed #cbd5e1; border-radius: 6px; font-size: 12px; }
-            .checklist-row { display: flex; justify-content: space-between; margin-top: 6px; }
-            .line { border-bottom: 1px solid #9ca3af; min-width: 120px; display: inline-block; height: 16px; }
+            .checklist { margin-top: 8px; padding: 8px; border: 1px dashed #94a3b8; border-radius: 6px; font-size: 12px; }
+            .checklist-row { display: flex; justify-content: space-between; align-items: center; margin-top: 8px; gap: 12px; }
+            .line { border-bottom: 2px solid #334155; min-width: 180px; display: inline-block; height: 16px; opacity: 1; }
             .actions { display: flex; gap: 8px; padding: 0 16px 14px; }
             .btn { flex: 1; border: none; border-radius: 8px; padding: 10px 12px; font-weight: 600; cursor: pointer; }
             .btn-print-kitchen { background: #111827; color: white; }
@@ -1387,7 +1390,7 @@ export function OrderManager({ selectedOrderId, setSelectedOrderId, restaurantId
                 <div class="customer-only checklist">
                   <strong>Pickup Verification</strong>
                   <div class="checklist-row"><span>Received by:</span><span class="line"></span></div>
-                  <div class="checklist-row"><span>Time:</span><span class="line"></span></div>
+                  <div class="checklist-row"><span>Received at (Date &amp; Time):</span><span class="line"></span></div>
                 </div>
               </div>
 

--- a/src/ordering/types/order.ts
+++ b/src/ordering/types/order.ts
@@ -8,7 +8,14 @@ export interface OrderItem {
   quantity: number;
   options?: string[];
   notes?: string;
-  customizations?: any[];
+  customizations?: any[] | Record<string, any>;
+}
+
+export interface OrderPayment {
+  id: string | number;
+  payment_method?: string;
+  status?: string;
+  created_at?: string;
 }
 
 export interface MerchandiseOrderItem {
@@ -42,6 +49,10 @@ export interface Order {
   contact_email?: string;
   pickup_time?: string;
   payment_method?: string;
+  payment_status?: string;
+  total_refunded?: number;
+  order_payments?: OrderPayment[];
+  location_name?: string;
   transaction_id?: string;
   restaurant_id?: string;
   staff_created?: boolean; // Flag to indicate if order was created by staff

--- a/src/ordering/types/order.ts
+++ b/src/ordering/types/order.ts
@@ -36,7 +36,7 @@ export interface Order {
   updated_at?: string;
   createdAt?: string;
   updatedAt?: string;
-  status: 'pending' | 'confirmed' | 'preparing' | 'ready' | 'completed' | 'cancelled' | 'error';
+  status: 'pending' | 'confirmed' | 'preparing' | 'ready' | 'completed' | 'cancelled' | 'refunded' | 'error';
   items: OrderItem[];
   merchandise_items?: MerchandiseOrderItem[];
   total: number;


### PR DESCRIPTION
## Summary\n- add a Print Order action button to Order Management rows\n- open a print-friendly popup with order number, contact info, pickup time, status, line items, notes, and total\n- trigger browser print flow for fast fulfillment printing\n\n## Testing\n- npm run build\n- manually verify Print Order button appears in admin orders and opens print dialog

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a **Print Order** action to the `OrderManager` admin interface. Clicking the print button opens a self-contained popup with a complete receipt layout — covering order metadata, all line items (food + merchandise), customizations, special instructions, subtotal/tax/tip breakdown, refund-aware net total, and payment info. The popup provides "Print Customer Copy" and "Print FOH Copy" buttons that auto-close after printing.

**Implementation quality:**
- All user-controlled fields are properly HTML-escaped to prevent XSS
- Both `order.items` and `order.merchandise_items` are merged for a complete receipt
- Customizations are handled in both array and object forms with proper fallbacks for edge cases (objects without `name` property, etc.)
- Item metadata (size, color, options) are rendered alongside customizations
- Special instructions, subtotal, tax, and tip are all displayed when present
- Refund amounts are computed correctly (net total = original total - refunded), with the refund line displayed separately
- Payment method and status are resolved by sorting `order_payments` by `created_at` descending
- `window.onafterprint` listener auto-closes the popup after printing
- `window.open` is called only after the full HTML is computed, preventing blank popups on error
- `formatPrintDateTime` safely handles null/undefined/invalid dates, returning "N/A"
- Pickup time defaults to "N/A" (not the order creation time) when absent
- Payment status falls back to "unknown" rather than asserting an unconfirmed "paid" state
- Layout includes proper DOCTYPE, charset, and responsive print styles

**Type safety:**
The companion changes in `order.ts` correctly formalize the runtime fields (`payment_status`, `total_refunded`, `order_payments`, `location_name`) that were previously accessed without type safety. The `customizations` field is properly widened to `any[] | Record<string, any>` to reflect real-world API variations.

The feature is well-implemented with careful attention to edge cases, browser compatibility (setTimeout before print to flush reflow), and security (HTML escaping). Manual testing is the primary safety net since this is entirely new UI with no automated test coverage.

<h3>Confidence Score: 4/5</h3>

- Safe to merge. Print feature is well-implemented with comprehensive XSS protection, proper window lifecycle management, and full order data coverage. All prior security and functional issues have been resolved.
- Confidence is 4/5 (not 5) solely because the feature is entirely new UI with no automated test coverage, making manual verification the only safety net. The implementation itself is thorough and correct — all previously identified concerns (XSS, popup handling, refund totals, missing fields, type safety) have been properly addressed. The code demonstrates careful attention to edge cases, browser compatibility, and security practices.
- No files require special attention.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor Admin
    participant OrderManager
    participant PrintPopup

    Admin->>OrderManager: Clicks Print Order button
    OrderManager->>OrderManager: handlePrintOrder(order)
    OrderManager->>OrderManager: Escape all user-controlled fields (escapeHtml)
    OrderManager->>OrderManager: Build itemsHtml (items + merchandise_items merged)
    OrderManager->>OrderManager: Compute net total (total - total_refunded)
    OrderManager->>OrderManager: Resolve payment info (order_payments sorted by created_at desc)
    OrderManager->>OrderManager: Build full receiptHtml string with all metadata
    OrderManager->>PrintPopup: window.open('', '_blank', 'width=420,height=700')
    OrderManager->>PrintPopup: printWindow.document.write(receiptHtml)
    OrderManager->>PrintPopup: printWindow.document.close()
    OrderManager->>PrintPopup: printWindow.focus()

    Admin->>PrintPopup: Clicks "Print Customer Copy" or "Print FOH Copy"
    PrintPopup->>PrintPopup: setMode(mode) — toggles body.mode-kitchen/mode-customer
    PrintPopup->>PrintPopup: setTimeout(0) — flush reflow before print
    PrintPopup->>PrintPopup: window.onafterprint = () => window.close()
    PrintPopup->>Admin: window.print() — opens browser print dialog
    Admin->>PrintPopup: Dismisses print dialog
    PrintPopup->>PrintPopup: onafterprint fires → window.close()
```

<sub>Last reviewed commit: a1326b8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->