### PR TITLE
HAF frontend hotfix: prevent duplicate submit taps (clean)

### DIFF
--- a/src/ordering/store/orderStore.ts
+++ b/src/ordering/store/orderStore.ts
@@ -52,6 +52,7 @@ interface OrderStore {
   orders: Order[];
   metadata: OrdersMetadata;
   loading: boolean;
+  isPlacingOrder: boolean;
   error: string | null;
   websocketConnected: boolean;
   pollingInterval: number | null;
@@ -122,6 +123,7 @@ export const useOrderStore = create<OrderStore>()(
         total_pages: 0
       },
       loading: false,
+      isPlacingOrder: false,
       error: null,
       websocketConnected: false,
       pollingInterval: null,
@@ -710,9 +712,18 @@ export const useOrderStore = create<OrderStore>()(
         paymentDetails = null,
         locationId = null
       ) => {
+        // Guard against duplicate submit taps/clicks
+        if (get().isPlacingOrder) {
+          return {
+            id: `duplicate-${Date.now()}`,
+            status: 'error',
+            error: 'Order is already being submitted. Please wait.'
+          } as any;
+        }
+
         // Skip setting loading state since we're showing a payment processing overlay already
         // This avoids unnecessary UI updates that can slow down the process
-        set({ error: null });
+        set({ error: null, isPlacingOrder: true });
         try {
           // Separate food vs merchandise
           const foodItems = [];
@@ -814,6 +825,8 @@ export const useOrderStore = create<OrderStore>()(
             status: 'error',
             error: err.message
           } as any;
+        } finally {
+          set({ isPlacingOrder: false });
         }
       },
 


### PR DESCRIPTION
Clean single-commit PR containing only submit-lock changes for duplicate-tap prevention.\n\n- adds isPlacingOrder guard in order store\n- prevents duplicate addOrder submits while request is in-flight\n- resets flag in finally

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully adds a lightweight `isPlacingOrder` guard to prevent duplicate order submissions when users tap the submit button multiple times. The implementation is correct and minimal:

- Flag is properly initialized to `false` at store creation
- Guard blocks duplicate submissions at the start of `addOrder` (line 716)
- Flag is set to `true` before the API call and reset in the `finally` block, ensuring cleanup regardless of success/failure
- The `partialize` persist config excludes the flag from localStorage, so it never persists across page reloads

The PR is safe to merge.

<h3>Confidence Score: 5/5</h3>

- The PR is safe to merge — the duplicate-tap guard is correctly implemented and guaranteed to clean up in all scenarios.
- The PR introduces a focused, minimal fix that prevents duplicate order submissions. The `isPlacingOrder` flag is properly initialized, gated, and cleaned up via `finally`. The flag is excluded from persistence so it doesn't carry over across page reloads. No pre-existing bugs were found in the error-handling path.
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as UI Component
    participant Store as orderStore
    participant API as Rails API

    UI->>Store: addOrder(items, ...)
    alt isPlacingOrder === true
        Store-->>UI: { status: 'error', error: 'Already submitting...' }
    else isPlacingOrder === false
        Store->>Store: set({ isPlacingOrder: true, error: null })
        Store->>Store: add optimisticOrder to orders[]
        Store->>API: POST /orders
        alt API success
            API-->>Store: newOrder
            Store->>Store: replace optimisticOrder with newOrder
            Store->>Store: clear cartItems
            Store-->>UI: newOrder
        else API failure
            API-->>Store: error
            Store->>Store: remove optimisticOrder from orders[]
            Store-->>UI: { status: 'error', error: err.message }
        end
        Store->>Store: finally: set({ isPlacingOrder: false })
    end
```

<sub>Last reviewed commit: bd6aa0b</sub>

<!-- /greptile_comment -->