### PR TITLE
Harden checkout recovery and frontend exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "react-swipeable": "^7.0.2",
         "react-window": "^1.8.11",
         "recharts": "^2.12.2",
-        "xlsx": "^0.18.5",
         "zustand": "^4.5.6"
       },
       "devDependencies": {
@@ -78,12 +77,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.25.7",
-        "picocolors": "^1.0.0"
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -211,17 +212,19 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-      "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -236,38 +239,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
-      "integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.7",
-        "@babel/types": "^7.25.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.7.tgz",
-      "integrity": "sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.7"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -307,24 +298,23 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
-      "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -356,13 +346,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.7.tgz",
-      "integrity": "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.7",
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1020,12 +1010,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1366,216 +1371,359 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
-      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
-      "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.0.tgz",
+      "integrity": "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
-      "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.0.tgz",
+      "integrity": "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
-      "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.0.tgz",
+      "integrity": "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
-      "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.0.tgz",
+      "integrity": "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.0.tgz",
+      "integrity": "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.0.tgz",
+      "integrity": "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
-      "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.0.tgz",
+      "integrity": "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
-      "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.0.tgz",
+      "integrity": "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
-      "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.0.tgz",
+      "integrity": "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
-      "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.0.tgz",
+      "integrity": "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
-      "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.0.tgz",
+      "integrity": "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.0.tgz",
+      "integrity": "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.0.tgz",
+      "integrity": "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
-      "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.0.tgz",
+      "integrity": "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.0.tgz",
+      "integrity": "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
-      "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.0.tgz",
+      "integrity": "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
-      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
-      "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.0.tgz",
+      "integrity": "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
-      "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.0.tgz",
+      "integrity": "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.0.tgz",
+      "integrity": "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.0.tgz",
+      "integrity": "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
-      "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.0.tgz",
+      "integrity": "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
-      "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.0.tgz",
+      "integrity": "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1731,10 +1879,11 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1940,21 +2089,23 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2067,19 +2218,24 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
       "engines": {
-        "node": ">=0.8"
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2107,6 +2263,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2157,7 +2314,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -2197,13 +2355,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -2299,6 +2459,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2336,22 +2509,11 @@
         }
       ]
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2405,18 +2567,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -2424,12 +2579,14 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2532,29 +2689,20 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
       "engines": {
         "node": ">= 6"
       }
     },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2745,6 +2893,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2786,6 +2935,20 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2810,6 +2973,51 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2863,6 +3071,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3261,21 +3470,23 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -3302,24 +3513,19 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -3366,11 +3572,50 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -3399,21 +3644,23 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3442,6 +3689,18 @@
         "csstype": "^3.0.10"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3452,8 +3711,36 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -3473,6 +3760,19 @@
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/hyphenate-style-name": {
@@ -3627,10 +3927,21 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3736,9 +4047,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -3788,6 +4100,15 @@
         "css-mediaquery": "^0.1.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/memoize-one": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
@@ -3819,6 +4140,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3827,6 +4149,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3835,10 +4158,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3872,9 +4196,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3882,6 +4206,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4071,15 +4396,17 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -4106,9 +4433,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -4124,9 +4451,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -4312,9 +4640,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4439,11 +4771,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.28.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.1.tgz",
-      "integrity": "sha512-2omQTA3rkMljmrvvo6WtewGdVh45SpL9hGiCI9uUrwGGfNFDIvGK4gYJsKlJoNVi6AQZcopSCballL+QGOm7fA==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.21.0"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4453,12 +4786,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.28.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.1.tgz",
-      "integrity": "sha512-YraE27C/RdjcZwl5UCqF/ffXnZDxpJdk9Q6jw38SZHjXs7NNdpViq2l2c7fO7+4uWaEfcwfGCv3RSg4e1By/fQ==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.21.0",
-        "react-router": "6.28.1"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4611,11 +4945,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -4651,12 +4980,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
-      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
+      "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.6"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4666,22 +4996,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.24.0",
-        "@rollup/rollup-android-arm64": "4.24.0",
-        "@rollup/rollup-darwin-arm64": "4.24.0",
-        "@rollup/rollup-darwin-x64": "4.24.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
-        "@rollup/rollup-linux-arm64-musl": "4.24.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
-        "@rollup/rollup-linux-x64-gnu": "4.24.0",
-        "@rollup/rollup-linux-x64-musl": "4.24.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
-        "@rollup/rollup-win32-x64-msvc": "4.24.0",
+        "@rollup/rollup-android-arm-eabi": "4.61.0",
+        "@rollup/rollup-android-arm64": "4.61.0",
+        "@rollup/rollup-darwin-arm64": "4.61.0",
+        "@rollup/rollup-darwin-x64": "4.61.0",
+        "@rollup/rollup-freebsd-arm64": "4.61.0",
+        "@rollup/rollup-freebsd-x64": "4.61.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
+        "@rollup/rollup-linux-arm64-musl": "4.61.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
+        "@rollup/rollup-linux-loong64-musl": "4.61.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-musl": "4.61.0",
+        "@rollup/rollup-openbsd-x64": "4.61.0",
+        "@rollup/rollup-openharmony-arm64": "4.61.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
+        "@rollup/rollup-win32-x64-gnu": "4.61.0",
+        "@rollup/rollup-win32-x64-msvc": "4.61.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -4799,17 +5138,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/string-width": {
@@ -4951,6 +5279,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -5101,14 +5430,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5296,10 +5617,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
-      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5372,22 +5694,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/word-wrap": {
@@ -5542,26 +5848,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -5569,15 +5855,19 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-swipeable": "^7.0.2",
     "react-window": "^1.8.11",
     "recharts": "^2.12.2",
-    "xlsx": "^0.18.5",
     "zustand": "^4.5.6"
   },
   "devDependencies": {

--- a/src/ordering/OnlineOrderingApp.tsx
+++ b/src/ordering/OnlineOrderingApp.tsx
@@ -7,6 +7,7 @@ import { Hero } from './components/Hero';
 import { MenuPage } from './components/MenuPage';
 import { CartPage } from './components/CartPage';
 import { CheckoutPage } from './components/CheckoutPage';
+import { CheckoutReturn } from './components/CheckoutReturn';
 import { OrderConfirmation } from './components/OrderConfirmation';
 import MerchandisePage from './components/MerchandisePage';
 // Lazy load AdminDashboard to reduce initial bundle size
@@ -337,6 +338,7 @@ export default function OnlineOrderingApp() {
         {/* /cart => Cart */}
         <Route path="cart" element={<CartPage />} />
         <Route path="checkout" element={<CheckoutPage />} />
+        <Route path="checkout/return" element={<CheckoutReturn />} />
         <Route path="order-confirmation" element={<OrderConfirmation />} />
         <Route path="order-confirmation/:orderId" element={<OrderConfirmation />} />
 

--- a/src/ordering/components/CheckoutPage.tsx
+++ b/src/ordering/components/CheckoutPage.tsx
@@ -19,6 +19,7 @@ import { VipCodeInput } from './VipCodeInput';
 import { PayPalCheckout, PayPalCheckoutRef } from './payment/PayPalCheckout';
 import { StripeCheckout, StripeCheckoutRef } from './payment/StripeCheckout';
 import LocationSelector from './customer/LocationSelector';
+import { clearPendingCheckoutDraft, savePendingCheckoutDraft } from '../utils/pendingCheckout';
 
 interface CheckoutFormData {
   name: string;
@@ -28,6 +29,28 @@ interface CheckoutFormData {
   promoCode: string;
   vipCode: string;
 }
+
+interface CheckoutPaymentDetails {
+  status?: string;
+  payment_method?: string;
+  transaction_id?: string;
+  payment_date?: string;
+  payment_intent_id?: string;
+  processor?: string;
+  notes?: string;
+  staffOrderParams?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+type CheckoutApiError = {
+  response?: {
+    data?: {
+      error?: string;
+      details?: unknown;
+    };
+  };
+  message?: string;
+};
 
 /**
  * Allows a plus sign, then 3 or 4 digits for "area code," then exactly 7 more digits.
@@ -151,6 +174,18 @@ export function CheckoutPage() {
     setVipCodeValid(valid);
   };
 
+  const persistPendingStripeCheckout = () => {
+    const restaurantId = localStorage.getItem('restaurant_id') || import.meta.env.VITE_RESTAURANT_ID || '1';
+
+    savePendingCheckoutDraft({
+      restaurantId,
+      cartItems: cartItems.map((item) => ({ ...item })),
+      finalTotal,
+      formData: { ...formData },
+      locationId,
+    });
+  };
+
   // Handler for when payment completes successfully
   const handlePaymentSuccess = (details: {
     status: string;
@@ -179,7 +214,7 @@ export function CheckoutPage() {
     };
     
     // Submit the order with the transaction ID and payment details
-    submitOrder(details.transaction_id, paymentDetails);
+    void submitOrder(details.transaction_id, paymentDetails);
   };
 
   // Handler for payment errors
@@ -188,9 +223,10 @@ export function CheckoutPage() {
     toastUtils.error(`Payment failed: ${error.message}`);
     setPaymentProcessing(false);
     setIsSubmitting(false);
+    clearPendingCheckoutDraft();
   };
 
-  async function submitOrder(transactionId: string, paymentDetails?: any) {
+  async function submitOrder(transactionId: string, paymentDetails?: CheckoutPaymentDetails) {
     try {
       // Check if any item needs 24-hr notice
       const hasAny24hrItem = cartItems.some(
@@ -236,6 +272,7 @@ export function CheckoutPage() {
         locationId // Include the selected location ID
       );
 
+      clearPendingCheckoutDraft();
       toastUtils.success('Order placed successfully!');
 
       const estimatedTime = hasAny24hrItem ? '24 hours' : '20–25 min';
@@ -253,7 +290,7 @@ export function CheckoutPage() {
         }
       }
       
-      navigate('/order-confirmation', {
+      navigate(`/order-confirmation/${newOrder.id}`, {
         state: {
           orderDetails: {
             ...newOrder,
@@ -262,7 +299,7 @@ export function CheckoutPage() {
             requires_advance_notice: hasAny24hrItem,
             max_advance_notice_hours: hasAny24hrItem ? 24 : undefined,
           },
-          orderId: newOrder.order_number || newOrder.id || '12345',
+          orderId: newOrder.id,
           total: finalTotal,
           estimatedTime,
           hasAny24hrItem,
@@ -270,20 +307,28 @@ export function CheckoutPage() {
           locationAddress,
         },
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Failed to create order:', err);
+      const apiError = err as CheckoutApiError;
 
       // Parse backend error details (e.g., stock insufficient, items not found)
-      const backendError = err?.response?.data?.error;
-      const backendDetails = err?.response?.data?.details;
+      const backendError = apiError.response?.data?.error;
+      const backendDetails = apiError.response?.data?.details;
 
-      if (backendDetails && Array.isArray(backendDetails)) {
+      if (Array.isArray(backendDetails)) {
         // Show each detail as a separate toast (e.g., "T-Shirt: only 2 available")
-        backendDetails.forEach((detail: string) => toastUtils.error(detail));
+        backendDetails.forEach((detail) => toastUtils.error(String(detail)));
       } else if (backendError) {
         toastUtils.error(backendError);
       } else {
-        toastUtils.error(err.message || 'Failed to place order. Please try again.');
+        toastUtils.error(apiError.message || 'Failed to place order. Please try again.');
+      }
+
+      if (paymentDetails?.processor === 'stripe' && paymentDetails?.payment_intent_id) {
+        navigate(`/checkout/return?payment_intent=${encodeURIComponent(paymentDetails.payment_intent_id)}`, {
+          replace: true,
+        });
+        return;
       }
 
       setIsSubmitting(false);
@@ -314,7 +359,7 @@ export function CheckoutPage() {
           // Code is valid, update state and continue
           setVipCodeValid(true);
           toastUtils.success('VIP code validated successfully!');
-        } catch (error) {
+        } catch {
           if (validationToast) validationToast.dismiss();
           toastUtils.error('Failed to validate VIP code');
           setIsSubmitting(false);
@@ -351,11 +396,13 @@ export function CheckoutPage() {
       setPaymentProcessing(true);
       
       if (isStripe && stripeRef.current) {
+        persistPendingStripeCheckout();
         // Process with Stripe
         const success = await stripeRef.current.processPayment();
         if (!success) {
           setPaymentProcessing(false);
           setIsSubmitting(false);
+          clearPendingCheckoutDraft();
         }
       } else if (paypalRef.current) {
         // Process with PayPal
@@ -371,7 +418,7 @@ export function CheckoutPage() {
         setIsSubmitting(false);
       }
       
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Failed during checkout process:', err);
       toastUtils.error('Failed to process checkout. Please try again.');
       setIsSubmitting(false);
@@ -490,6 +537,7 @@ export function CheckoutPage() {
                 {/* Conditionally render PayPal or Stripe checkout based on payment processor setting */}
                 {restaurant?.admin_settings?.payment_gateway?.payment_processor === 'stripe' ? (
                   <StripeCheckout
+                    key={`stripe-${finalTotal}`}
                     ref={stripeRef}
                     amount={finalTotal.toString()}
                     publishableKey={(restaurant?.admin_settings?.payment_gateway?.publishable_key as string) || ""}
@@ -615,8 +663,8 @@ export function CheckoutPage() {
                       <p className="text-sm text-gray-500">Qty: {item.quantity}</p>
                       {item.customizations && Object.keys(item.customizations).length > 0 && (
                         <p className="text-xs text-gray-500">
-                          {Object.entries(item.customizations)
-                            .map(([_, options]) => `${options.join(', ')}`)
+                          {Object.values(item.customizations)
+                            .map((options) => (Array.isArray(options) ? options.join(', ') : String(options)))
                             .join('; ')}
                         </p>
                       )}

--- a/src/ordering/components/CheckoutPage.tsx
+++ b/src/ordering/components/CheckoutPage.tsx
@@ -181,7 +181,13 @@ export function CheckoutPage() {
       restaurantId,
       cartItems: cartItems.map((item) => ({ ...item })),
       finalTotal,
-      formData: { ...formData },
+      formData: {
+        name: formData.name,
+        email: formData.email,
+        phone: formData.phone,
+        specialInstructions: formData.specialInstructions,
+        vipCode: formData.vipCode,
+      },
       locationId,
     });
   };

--- a/src/ordering/components/CheckoutReturn.tsx
+++ b/src/ordering/components/CheckoutReturn.tsx
@@ -124,7 +124,7 @@ export function CheckoutReturn() {
     const finalizeOrder = async () => {
       const paymentIntentId = searchParams.get('payment_intent');
       const redirectStatus = searchParams.get('redirect_status');
-      const paymentIntentClientSecret = searchParams.get('payment_intent_client_secret');
+      const redirectPaymentIntentClientSecret = searchParams.get('payment_intent_client_secret');
       const draft = loadPendingCheckoutDraft();
       const restaurantId = localStorage.getItem('restaurant_id') || import.meta.env.VITE_RESTAURANT_ID || '1';
 
@@ -147,11 +147,12 @@ export function CheckoutReturn() {
           return;
         }
 
-        if (paymentIntentClientSecret) {
+        const lookupClientSecret = redirectPaymentIntentClientSecret || paymentIntent.client_secret;
+        if (lookupClientSecret) {
           const existingOrder = await stripeApi.findOrderByTransaction(
             paymentIntent.id,
             restaurantId,
-            paymentIntentClientSecret
+            lookupClientSecret
           );
           if (existingOrder) {
             await navigateToConfirmation(normalizeRecoveredOrder(existingOrder, draft), draft);

--- a/src/ordering/components/CheckoutReturn.tsx
+++ b/src/ordering/components/CheckoutReturn.tsx
@@ -5,7 +5,9 @@ import { LoadingSpinner } from '../../shared/components/ui';
 import { locationsApi } from '../../shared/api/endpoints/locations';
 import { stripeApi } from '../../shared/api/endpoints/stripe';
 import { useOrderStore } from '../store/orderStore';
+import type { Order } from '../types/order';
 import { clearPendingCheckoutDraft, loadPendingCheckoutDraft } from '../utils/pendingCheckout';
+import type { PendingCheckoutDraft } from '../utils/pendingCheckout';
 
 type FinalizeState = 'processing' | 'error';
 
@@ -27,11 +29,55 @@ export function CheckoutReturn() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const addOrder = useOrderStore((state) => state.addOrder);
+  const clearCart = useOrderStore((state) => state.clearCart);
   const [state, setState] = useState<FinalizeState>('processing');
   const [message, setMessage] = useState('Finalizing your order...');
 
   useEffect(() => {
     let cancelled = false;
+
+    const navigateToConfirmation = async (order: Order, draft: PendingCheckoutDraft | null) => {
+      let locationName = '';
+      let locationAddress = '';
+      const hasAny24hrItem = draft?.cartItems.some((item) => (item.advance_notice_hours ?? 0) >= 24) ?? false;
+
+      if (draft?.locationId) {
+        try {
+          const location = await locationsApi.getLocation(draft.locationId);
+          locationName = location.name;
+          locationAddress = location.address;
+        } catch (error) {
+          console.error('Error fetching location details for recovered confirmation:', error);
+        }
+      }
+
+      clearPendingCheckoutDraft();
+      clearCart();
+
+      if (!cancelled) {
+        navigate(`/order-confirmation/${order.id}`, {
+          replace: true,
+          state: {
+            orderDetails: {
+              ...order,
+              ...(draft
+                ? {
+                    location_name: locationName,
+                    location_address: locationAddress,
+                    requires_advance_notice: hasAny24hrItem,
+                    max_advance_notice_hours: hasAny24hrItem ? 24 : undefined,
+                  }
+                : {}),
+            },
+            orderId: order.id,
+            total: draft?.finalTotal ?? order.total,
+            hasAny24hrItem,
+            locationName,
+            locationAddress,
+          },
+        });
+      }
+    };
 
     const finalizeOrder = async () => {
       const paymentIntentId = searchParams.get('payment_intent');
@@ -45,12 +91,6 @@ export function CheckoutReturn() {
         return;
       }
 
-      if (!draft) {
-        setState('error');
-        setMessage('We could not recover your checkout details. Please contact support before trying again.');
-        return;
-      }
-
       try {
         const paymentIntent = await stripeApi.getPaymentIntent(paymentIntentId, restaurantId);
 
@@ -61,6 +101,18 @@ export function CheckoutReturn() {
               ? 'Your payment was not completed.'
               : `Your payment is currently ${paymentIntent.status}.`
           );
+          return;
+        }
+
+        const existingOrder = await stripeApi.findOrderByTransaction(paymentIntent.id, restaurantId);
+        if (existingOrder) {
+          await navigateToConfirmation(existingOrder as unknown as Order, draft);
+          return;
+        }
+
+        if (!draft) {
+          setState('error');
+          setMessage('We could not recover your checkout details. Please contact support before trying again.');
           return;
         }
 
@@ -89,41 +141,7 @@ export function CheckoutReturn() {
           draft.locationId ?? null
         );
 
-        let locationName = '';
-        let locationAddress = '';
-        const hasAny24hrItem = draft.cartItems.some((item) => (item.advance_notice_hours ?? 0) >= 24);
-
-        if (draft.locationId) {
-          try {
-            const location = await locationsApi.getLocation(draft.locationId);
-            locationName = location.name;
-            locationAddress = location.address;
-          } catch (error) {
-            console.error('Error fetching location details for recovered confirmation:', error);
-          }
-        }
-
-        clearPendingCheckoutDraft();
-
-        if (!cancelled) {
-          navigate(`/order-confirmation/${newOrder.id}`, {
-            replace: true,
-            state: {
-              orderDetails: {
-                ...newOrder,
-                location_name: locationName,
-                location_address: locationAddress,
-                requires_advance_notice: hasAny24hrItem,
-                max_advance_notice_hours: hasAny24hrItem ? 24 : undefined,
-              },
-              orderId: newOrder.id,
-              total: draft.finalTotal,
-              hasAny24hrItem,
-              locationName,
-              locationAddress,
-            },
-          });
-        }
+        await navigateToConfirmation(newOrder, draft);
       } catch (error: unknown) {
         console.error('Failed to finalize Stripe checkout return:', error);
         setState('error');
@@ -136,7 +154,7 @@ export function CheckoutReturn() {
     return () => {
       cancelled = true;
     };
-  }, [addOrder, navigate, searchParams]);
+  }, [addOrder, clearCart, navigate, searchParams]);
 
   if (state === 'processing') {
     return (

--- a/src/ordering/components/CheckoutReturn.tsx
+++ b/src/ordering/components/CheckoutReturn.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { LoadingSpinner } from '../../shared/components/ui';
 import { locationsApi } from '../../shared/api/endpoints/locations';
 import { stripeApi } from '../../shared/api/endpoints/stripe';
+import type { OrderByTransactionResponse } from '../../shared/api/endpoints/stripe';
 import { useOrderStore } from '../store/orderStore';
 import type { Order } from '../types/order';
 import { clearPendingCheckoutDraft, loadPendingCheckoutDraft } from '../utils/pendingCheckout';
@@ -23,6 +24,47 @@ type ApiErrorLike = {
 function checkoutErrorMessage(error: unknown) {
   const apiError = error as ApiErrorLike;
   return apiError.response?.data?.error || apiError.message || 'We could not finalize your order.';
+}
+
+const ORDER_STATUSES: ReadonlySet<Order['status']> = new Set([
+  'pending',
+  'confirmed',
+  'preparing',
+  'ready',
+  'completed',
+  'cancelled',
+  'refunded',
+  'error',
+]);
+
+function isOrderStatus(value: unknown): value is Order['status'] {
+  return typeof value === 'string' && ORDER_STATUSES.has(value as Order['status']);
+}
+
+function numericValue(value: unknown, fallback: number) {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function normalizeRecoveredOrder(order: OrderByTransactionResponse, draft: PendingCheckoutDraft | null): Order {
+  return {
+    id: String(order.id),
+    order_number: typeof order.order_number === 'string' ? order.order_number : undefined,
+    status: isOrderStatus(order.status) ? order.status : 'pending',
+    total: numericValue(order.total, draft?.finalTotal ?? 0),
+    subtotal: order.subtotal === undefined ? undefined : numericValue(order.subtotal, 0),
+    tax: order.tax === undefined ? undefined : numericValue(order.tax, 0),
+    items: Array.isArray(order.items) ? (order.items as Order['items']) : [],
+    merchandise_items: Array.isArray(order.merchandise_items)
+      ? (order.merchandise_items as Order['merchandise_items'])
+      : [],
+    created_at: typeof order.created_at === 'string' ? order.created_at : undefined,
+    updated_at: typeof order.updated_at === 'string' ? order.updated_at : undefined,
+    estimated_pickup_time: typeof order.estimated_pickup_time === 'string' ? order.estimated_pickup_time : undefined,
+    location_name: typeof order.location_name === 'string' ? order.location_name : undefined,
+    location_address: typeof order.location_address === 'string' ? order.location_address : undefined,
+    location_id: typeof order.location_id === 'number' ? order.location_id : undefined,
+  };
 }
 
 export function CheckoutReturn() {
@@ -82,6 +124,7 @@ export function CheckoutReturn() {
     const finalizeOrder = async () => {
       const paymentIntentId = searchParams.get('payment_intent');
       const redirectStatus = searchParams.get('redirect_status');
+      const paymentIntentClientSecret = searchParams.get('payment_intent_client_secret');
       const draft = loadPendingCheckoutDraft();
       const restaurantId = localStorage.getItem('restaurant_id') || import.meta.env.VITE_RESTAURANT_ID || '1';
 
@@ -104,10 +147,16 @@ export function CheckoutReturn() {
           return;
         }
 
-        const existingOrder = await stripeApi.findOrderByTransaction(paymentIntent.id, restaurantId);
-        if (existingOrder) {
-          await navigateToConfirmation(existingOrder as unknown as Order, draft);
-          return;
+        if (paymentIntentClientSecret) {
+          const existingOrder = await stripeApi.findOrderByTransaction(
+            paymentIntent.id,
+            restaurantId,
+            paymentIntentClientSecret
+          );
+          if (existingOrder) {
+            await navigateToConfirmation(normalizeRecoveredOrder(existingOrder, draft), draft);
+            return;
+          }
         }
 
         if (!draft) {

--- a/src/ordering/components/CheckoutReturn.tsx
+++ b/src/ordering/components/CheckoutReturn.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+
+import { LoadingSpinner } from '../../shared/components/ui';
+import { locationsApi } from '../../shared/api/endpoints/locations';
+import { stripeApi } from '../../shared/api/endpoints/stripe';
+import { useOrderStore } from '../store/orderStore';
+import { clearPendingCheckoutDraft, loadPendingCheckoutDraft } from '../utils/pendingCheckout';
+
+type FinalizeState = 'processing' | 'error';
+
+type ApiErrorLike = {
+  response?: {
+    data?: {
+      error?: string;
+    };
+  };
+  message?: string;
+};
+
+function checkoutErrorMessage(error: unknown) {
+  const apiError = error as ApiErrorLike;
+  return apiError.response?.data?.error || apiError.message || 'We could not finalize your order.';
+}
+
+export function CheckoutReturn() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const addOrder = useOrderStore((state) => state.addOrder);
+  const [state, setState] = useState<FinalizeState>('processing');
+  const [message, setMessage] = useState('Finalizing your order...');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const finalizeOrder = async () => {
+      const paymentIntentId = searchParams.get('payment_intent');
+      const redirectStatus = searchParams.get('redirect_status');
+      const draft = loadPendingCheckoutDraft();
+      const restaurantId = localStorage.getItem('restaurant_id') || import.meta.env.VITE_RESTAURANT_ID || '1';
+
+      if (!paymentIntentId) {
+        setState('error');
+        setMessage('We could not verify your payment because the payment reference is missing.');
+        return;
+      }
+
+      if (!draft) {
+        setState('error');
+        setMessage('We could not recover your checkout details. Please contact support before trying again.');
+        return;
+      }
+
+      try {
+        const paymentIntent = await stripeApi.getPaymentIntent(paymentIntentId, restaurantId);
+
+        if (paymentIntent.status !== 'succeeded') {
+          setState('error');
+          setMessage(
+            redirectStatus === 'failed'
+              ? 'Your payment was not completed.'
+              : `Your payment is currently ${paymentIntent.status}.`
+          );
+          return;
+        }
+
+        const paymentDetails = {
+          status: paymentIntent.status,
+          payment_method: 'stripe',
+          transaction_id: paymentIntent.id,
+          payment_date: new Date().toISOString().split('T')[0],
+          payment_intent_id: paymentIntent.id,
+          processor: 'stripe',
+          notes: 'Order finalized from Stripe payment recovery flow',
+        };
+
+        const newOrder = await addOrder(
+          draft.cartItems,
+          draft.finalTotal,
+          draft.formData.specialInstructions,
+          draft.formData.name,
+          draft.formData.phone,
+          draft.formData.email,
+          paymentIntent.id,
+          'stripe',
+          draft.formData.vipCode,
+          false,
+          paymentDetails,
+          draft.locationId ?? null
+        );
+
+        let locationName = '';
+        let locationAddress = '';
+        const hasAny24hrItem = draft.cartItems.some((item) => (item.advance_notice_hours ?? 0) >= 24);
+
+        if (draft.locationId) {
+          try {
+            const location = await locationsApi.getLocation(draft.locationId);
+            locationName = location.name;
+            locationAddress = location.address;
+          } catch (error) {
+            console.error('Error fetching location details for recovered confirmation:', error);
+          }
+        }
+
+        clearPendingCheckoutDraft();
+
+        if (!cancelled) {
+          navigate(`/order-confirmation/${newOrder.id}`, {
+            replace: true,
+            state: {
+              orderDetails: {
+                ...newOrder,
+                location_name: locationName,
+                location_address: locationAddress,
+                requires_advance_notice: hasAny24hrItem,
+                max_advance_notice_hours: hasAny24hrItem ? 24 : undefined,
+              },
+              orderId: newOrder.id,
+              total: draft.finalTotal,
+              hasAny24hrItem,
+              locationName,
+              locationAddress,
+            },
+          });
+        }
+      } catch (error: unknown) {
+        console.error('Failed to finalize Stripe checkout return:', error);
+        setState('error');
+        setMessage(checkoutErrorMessage(error));
+      }
+    };
+
+    void finalizeOrder();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [addOrder, navigate, searchParams]);
+
+  if (state === 'processing') {
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="bg-white rounded-lg shadow-md p-8 text-center">
+          <LoadingSpinner text="Finalizing your order" className="mb-4" />
+          <p className="text-gray-600">{message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div className="bg-white rounded-lg shadow-md p-8 text-center">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">We Couldn&apos;t Confirm Your Order</h1>
+        <p className="text-lg text-red-600 mb-4">{message}</p>
+        <p className="text-gray-600 mb-8">
+          If you saw an approval from your payment provider, please contact support so we can verify the payment before you try again.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Link
+            to="/checkout"
+            className="inline-flex items-center justify-center px-6 py-3 rounded-md text-white bg-[#c1902f] hover:bg-[#d4a43f]"
+          >
+            Return to Checkout
+          </Link>
+          <Link
+            to="/menu"
+            className="inline-flex items-center justify-center px-6 py-3 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+          >
+            Back to Menu
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ordering/components/OrderConfirmation.tsx
+++ b/src/ordering/components/OrderConfirmation.tsx
@@ -87,7 +87,7 @@ export function OrderConfirmation() {
         setLoading(true);
         const response = await api.get<OrderDetails>(`/orders/${orderId}`);
         setOrderDetails(response);
-      } catch (err: any) {
+      } catch (err: unknown) {
         console.error('Failed to fetch order details:', err);
         setError('Unable to load order details');
       } finally {
@@ -156,9 +156,11 @@ export function OrderConfirmation() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="max-w-2xl mx-auto text-center">
           <h1 className="text-3xl font-bold text-gray-900 mb-4">Order Confirmation</h1>
-          <p className="text-lg text-red-600 mb-4">{error || 'Order details not available'}</p>
+          <p className="text-lg text-red-600 mb-4">{error || 'We could not verify your order details'}</p>
           <p className="text-gray-600 mb-8">
-            Order #{orderId} {error ? 'could not be loaded' : 'has been received'}
+            {orderId !== 'N/A'
+              ? `Order #${orderId} could not be verified.`
+              : 'We do not have a confirmed order reference for this checkout.'}
           </p>
           <Link
             to="/menu"

--- a/src/ordering/components/admin/AnalyticsManager.tsx
+++ b/src/ordering/components/admin/AnalyticsManager.tsx
@@ -5,7 +5,7 @@ import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
   ResponsiveContainer, PieChart, Pie, Cell
 } from 'recharts';
-import * as XLSX from 'xlsx';
+import * as XLSX from '../../../shared/utils/simpleSpreadsheet';
 import {
   api,
   getCustomerOrdersReport,

--- a/src/ordering/components/admin/reports/MenuItemPerformance.tsx
+++ b/src/ordering/components/admin/reports/MenuItemPerformance.tsx
@@ -1,7 +1,7 @@
 // src/ordering/components/admin/reports/MenuItemPerformance.tsx
 import React, { useState, useMemo } from 'react';
 import { MenuItemReport, CategoryReport, MenuItemOrderDetail } from '../../../../shared/api';
-import * as XLSX from 'xlsx';
+import * as XLSX from '../../../../shared/utils/simpleSpreadsheet';
 
 interface MenuItemPerformanceProps {
   menuItems: MenuItemReport[];

--- a/src/ordering/components/admin/reports/PaymentMethodReport.tsx
+++ b/src/ordering/components/admin/reports/PaymentMethodReport.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useMemo } from 'react';
 import { PaymentMethodReport as PaymentMethodReportType, PaymentMethodOrderDetail } from '../../../../shared/api';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import * as XLSX from 'xlsx';
+import * as XLSX from '../../../../shared/utils/simpleSpreadsheet';
 
 // Simplified color palette
 const COLORS = [

--- a/src/ordering/components/admin/reports/RefundsReport.tsx
+++ b/src/ordering/components/admin/reports/RefundsReport.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
   Legend
 } from 'recharts';
-import * as XLSX from 'xlsx';
+import * as XLSX from '../../../../shared/utils/simpleSpreadsheet';
 import {
   RefundDetail,
   RefundsByMethod,

--- a/src/ordering/components/admin/reports/VipCustomerReport.tsx
+++ b/src/ordering/components/admin/reports/VipCustomerReport.tsx
@@ -1,7 +1,7 @@
 // src/ordering/components/admin/reports/VipCustomerReport.tsx
 import React, { useState, useMemo } from 'react';
 import { VipCustomerReport as VipCustomerReportType, VipReportSummary } from '../../../../shared/api';
-import * as XLSX from 'xlsx';
+import * as XLSX from '../../../../shared/utils/simpleSpreadsheet';
 
 interface VipCustomerReportProps {
   vipCustomers: VipCustomerReportType[];

--- a/src/ordering/components/payment/PaymentBaseStyles.tsx
+++ b/src/ordering/components/payment/PaymentBaseStyles.tsx
@@ -14,18 +14,18 @@ export const brandColors = {
 
 // Shared button styles for both Stripe and PayPal components
 export const ButtonStyles = {
-  primary: `px-4 py-3 w-full bg-[${brandColors.primary}] text-white font-medium rounded-md 
-            hover:bg-[${brandColors.primaryHover}] focus:outline-none focus:ring-2 
-            focus:ring-[${brandColors.primary}] focus:ring-opacity-50 transition-colors duration-200`,
-  secondary: `px-4 py-3 w-full bg-gray-100 text-gray-700 font-medium rounded-md 
-              hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 
+  primary: `px-4 py-3 w-full bg-[#c1902f] text-white font-medium rounded-md
+            hover:bg-[#d4a43f] focus:outline-none focus:ring-2
+            focus:ring-[#c1902f] focus:ring-opacity-50 transition-colors duration-200`,
+  secondary: `px-4 py-3 w-full bg-gray-100 text-gray-700 font-medium rounded-md
+              hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500
               focus:ring-opacity-50 transition-colors duration-200`,
 };
 
 // Shared input field styles
 export const InputStyles = {
   base: `w-full px-4 py-2 border border-gray-300 rounded-md
-         focus:ring-[${brandColors.primary}] focus:border-[${brandColors.primary}]`,
+         focus:ring-[#c1902f] focus:border-[#c1902f]`,
   disabled: `w-full px-4 py-2 border border-gray-300 rounded-md bg-gray-50 text-gray-500`,
 };
 
@@ -55,7 +55,7 @@ export const PaymentMethodSelector: React.FC<{
           type="button"
           className={`flex-1 py-2 text-center ${
             paymentMethod === option.id
-              ? `bg-[${brandColors.primary}] text-white`
+              ? 'bg-[#c1902f] text-white'
               : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
           }`}
           onClick={() => onChange(option.id)}

--- a/src/ordering/components/payment/StripeCheckout.tsx
+++ b/src/ordering/components/payment/StripeCheckout.tsx
@@ -1,14 +1,15 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+
 import { api } from '../../../shared/api/apiClient';
 import { LoadingSpinner } from '../../../shared/components/ui';
 
-// Define the possible response types from the payment intent API
 interface PaymentIntentResponse {
   success: boolean;
   client_secret?: string;
   free_order?: boolean;
   small_order?: boolean;
   order_id?: string;
+  payment_intent_id?: string;
   errors?: string[];
   status?: string;
 }
@@ -21,14 +22,13 @@ interface StripeCheckoutProps {
   onPaymentSuccess: (details: {
     status: string;
     transaction_id: string;
-    payment_id?: string; // Added for webhook lookups
-    payment_intent_id?: string; // Added to explicitly track the payment intent ID
+    payment_id?: string;
+    payment_intent_id?: string;
     amount: string;
   }) => void;
   onPaymentError: (error: Error) => void;
 }
 
-// Create a ref type for accessing the component from parent
 export interface StripeCheckoutRef {
   processPayment: () => Promise<boolean>;
 }
@@ -40,27 +40,26 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
     publishableKey,
     testMode,
     onPaymentSuccess,
-    onPaymentError
+    onPaymentError,
   } = props;
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
-  const [clientSecret, setClientSecret] = useState<string | null>(null);
   const [stripe, setStripe] = useState<any>(null);
   const [elements, setElements] = useState<any>(null);
+  const [cardElement, setCardElement] = useState<any>(null);
+  const [clientSecret, setClientSecret] = useState<string | null>(null);
   const [isFreeOrder, setIsFreeOrder] = useState(false);
   const [isSmallOrder, setIsSmallOrder] = useState(false);
   const [specialOrderId, setSpecialOrderId] = useState<string | null>(null);
 
-  // Use refs to track initialization state
   const stripeLoaded = useRef(false);
   const paymentIntentCreated = useRef(false);
   const elementsInitialized = useRef(false);
-  const paymentElementMounted = useRef(false);
-  const paymentElementRef = useRef<HTMLDivElement>(null);
+  const cardElementMounted = useRef(false);
+  const cardElementRef = useRef<HTMLDivElement>(null);
 
-  // Load Stripe.js - only once
   useEffect(() => {
     if (stripeLoaded.current || testMode) {
       setLoading(false);
@@ -68,7 +67,7 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
     }
 
     stripeLoaded.current = true;
-    
+
     if (!publishableKey) {
       setError('Stripe publishable key is missing');
       setLoading(false);
@@ -101,227 +100,188 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
     };
   }, [publishableKey, testMode]);
 
-  // Create payment intent - only once
   useEffect(() => {
-    // For test mode, just create a fake client secret
-    if (testMode && !clientSecret) {
-      setClientSecret(`test_secret_${Math.random().toString(36).substring(2, 15)}`);
-      return;
-    }
-
-    // Skip if already created, missing stripe, already have client secret, or have an error
-    if (paymentIntentCreated.current || !stripe || clientSecret || error) {
+    if (testMode || paymentIntentCreated.current || clientSecret || error || isFreeOrder || isSmallOrder) {
       return;
     }
 
     paymentIntentCreated.current = true;
-    
+
     const createPaymentIntent = async () => {
       try {
-        // Get restaurant ID from localStorage or use default
-        const restaurantId = localStorage.getItem('restaurant_id') || '1';
-        
+        const restaurantId = localStorage.getItem('restaurant_id') || import.meta.env.VITE_RESTAURANT_ID || '1';
         const response = await api.post<PaymentIntentResponse>('/stripe/create_intent', {
           amount,
           currency,
-          restaurant_id: restaurantId // Include restaurant_id for tenant isolation
+          restaurant_id: restaurantId,
         });
-        
-        // Check if this is a free or small order
-        if (response && (response.free_order || response.small_order)) {
-          if (response.free_order) {
-            setIsFreeOrder(true);
-          } else if (response.small_order) {
-            setIsSmallOrder(true);
-          }
+
+        if (response.free_order || response.small_order) {
+          setIsFreeOrder(Boolean(response.free_order));
+          setIsSmallOrder(Boolean(response.small_order));
           setSpecialOrderId(response.order_id || `special_${Math.random().toString(36).substring(2, 10)}`);
-          setLoading(false);
           return;
         }
-        
-        // Normal paid order with client secret
-        if (response && response.client_secret) {
-          setClientSecret(response.client_secret);
-        } else if (response && response.success) {
-          // This is a successful response but doesn't have a client secret
-          // (could be a free or small order that wasn't caught above)
-          setIsSmallOrder(true);
-          setSpecialOrderId(`special_${Math.random().toString(36).substring(2, 10)}`);
-          setLoading(false);
-        } else {
+
+        if (!response.client_secret) {
           throw new Error('No client secret returned');
         }
+
+        setClientSecret(response.client_secret);
       } catch (err: any) {
         setError(err.message || 'Failed to create payment intent');
         onPaymentError(err);
       }
     };
 
-    createPaymentIntent();
-  }, [stripe, testMode, clientSecret, error, amount, currency, onPaymentError]);
+    void createPaymentIntent();
+  }, [amount, clientSecret, currency, error, isFreeOrder, isSmallOrder, onPaymentError, testMode]);
 
-  // Initialize Stripe Elements - only once
   useEffect(() => {
-    if (elementsInitialized.current || testMode || !stripe || !clientSecret || isFreeOrder || isSmallOrder) {
+    if (testMode || !stripe || elementsInitialized.current || error || isFreeOrder || isSmallOrder) {
       return;
     }
-    
+
     elementsInitialized.current = true;
-    
-    const elementsInstance = stripe.elements({
-      clientSecret,
-      appearance: {
-        theme: 'stripe',
-        variables: {
-          colorPrimary: '#c1902f',
-        },
-      },
-      // Configure payment flow
-      paymentMethodCreation: 'manual',
-      // Minimize billing address collection
-      billingAddressCollection: 'never'
-    });
-    setElements(elementsInstance);
-  }, [stripe, clientSecret, testMode]);
 
-  // Mount payment element when elements is ready
+    try {
+      const elementsInstance = stripe.elements({
+        appearance: {
+          theme: 'stripe',
+          variables: {
+            colorPrimary: '#c1902f',
+            colorText: '#111827',
+            colorDanger: '#dc2626',
+            borderRadius: '8px',
+          },
+        },
+      });
+
+      setElements(elementsInstance);
+    } catch (err: any) {
+      setError(err.message || 'Failed to initialize Stripe Elements');
+      onPaymentError(err);
+    }
+  }, [error, isFreeOrder, isSmallOrder, onPaymentError, stripe, testMode]);
+
   useEffect(() => {
-    // Skip if already mounted or if we're in test mode or if elements isn't ready or if it's a special order
-    if (paymentElementMounted.current || testMode || !elements || !paymentElementRef.current || isFreeOrder || isSmallOrder) {
+    if (testMode || !elements || !cardElementRef.current || cardElementMounted.current || isFreeOrder || isSmallOrder) {
       return;
     }
-    
-    // Mark as mounted to prevent creating multiple elements
-    paymentElementMounted.current = true;
-    
-    // Create and mount the payment element with payment method configuration
-    const paymentElement = elements.create('payment', {
-      // Configure payment methods to prioritize card and digital wallets
-      payment_method_types: ['card', 'apple_pay', 'google_pay', 'cashapp'],
-      defaultValues: {
-        billingDetails: {
-          name: '',
-          email: '',
-          phone: ''
-        }
-      }
-    });
-    
-    // Mount the element
-    paymentElement.mount(paymentElementRef.current);
-    
-    // Cleanup function to unmount element when component unmounts
-    return () => {
-      if (paymentElementMounted.current && paymentElement) {
-        try {
-          paymentElement.unmount();
-        } catch (err) {
-          console.log('Error unmounting Stripe element:', err);
-          // Ignore errors during unmount - element might already be destroyed
-        }
-        paymentElementMounted.current = false;
-      }
-    };
-  }, [elements, testMode]);
 
-  // Process payment function - exposed to parent via ref
+    cardElementMounted.current = true;
+    let card: any = null;
+
+    try {
+      card = elements.create('card', {
+        hidePostalCode: true,
+        style: {
+          base: {
+            color: '#111827',
+            fontSize: '16px',
+            '::placeholder': {
+              color: '#9ca3af',
+            },
+          },
+          invalid: {
+            color: '#dc2626',
+          },
+        },
+      });
+
+      card.mount(cardElementRef.current);
+      setCardElement(card);
+
+      card.on('change', (event: any) => {
+        if (event.error) {
+          setError(event.error.message);
+        } else {
+          setError(null);
+        }
+      });
+    } catch (err: any) {
+      setError(err.message || 'Failed to mount card input');
+      onPaymentError(err);
+    }
+
+    return () => {
+      if (cardElementMounted.current && card) {
+        try {
+          card.unmount();
+        } catch (err) {
+          console.error('Error unmounting Stripe card element:', err);
+        }
+      }
+      cardElementMounted.current = false;
+    };
+  }, [elements, isFreeOrder, isSmallOrder, onPaymentError, testMode]);
+
   const processPayment = async (): Promise<boolean> => {
     if (processing) return false;
-    
+
     setProcessing(true);
-    
-    // Application test mode - simulate successful payment
+
     if (testMode) {
       setTimeout(() => {
-        // Generate a Stripe-like test payment intent ID
-        // This format matches what Stripe would generate in their test mode
         const testId = `pi_test_${Math.random().toString(36).substring(2, 15)}`;
         onPaymentSuccess({
           status: 'succeeded',
           transaction_id: testId,
-          payment_id: testId, // Use the same ID for payment_id
-          payment_intent_id: testId, // Also include as payment_intent_id
-          amount: amount,
+          payment_id: testId,
+          payment_intent_id: testId,
+          amount,
         });
         setProcessing(false);
       }, 1000);
+
       return true;
     }
-    
-    // Handle free orders
-    if (isFreeOrder) {
-      setTimeout(() => {
-        onPaymentSuccess({
-          status: 'succeeded',
-          transaction_id: specialOrderId || `free_${Math.random().toString(36).substring(2, 10)}`,
-          payment_id: specialOrderId || undefined, 
-          payment_intent_id: specialOrderId || undefined,
-          amount: '0',
-        });
-        setProcessing(false);
-      }, 500);
-      return true;
-    }
-    
-    // Handle free or small orders
+
     if (isFreeOrder || isSmallOrder) {
       setTimeout(() => {
         onPaymentSuccess({
           status: 'succeeded',
           transaction_id: specialOrderId || `special_${Math.random().toString(36).substring(2, 10)}`,
-          payment_id: specialOrderId || undefined, 
+          payment_id: specialOrderId || undefined,
           payment_intent_id: specialOrderId || undefined,
           amount: isFreeOrder ? '0' : '0.50',
         });
         setProcessing(false);
       }, 500);
+
       return true;
     }
-    
-    // Live mode - need stripe and elements
-    if (!stripe || !elements || !clientSecret) {
+
+    if (!stripe || !cardElement || !clientSecret) {
+      setError('Stripe is not ready yet');
       setProcessing(false);
       return false;
     }
-    
+
     try {
-      const { error: submitError, paymentIntent } = await stripe.confirmPayment({
-        elements,
-        confirmParams: {
-          return_url: window.location.origin + '/order-confirmation',
+      const { error: confirmError, paymentIntent } = await stripe.confirmCardPayment(clientSecret, {
+        payment_method: {
+          card: cardElement,
         },
-        redirect: 'if_required',
       });
 
-      if (submitError) {
-        setError(submitError.message || 'Payment failed');
-        onPaymentError(new Error(submitError.message || 'Payment failed'));
-        return false;
-      } 
-      
-      if (paymentIntent && paymentIntent.status === 'succeeded') {
-        // Payment succeeded
-        onPaymentSuccess({
-          status: paymentIntent.status,
-          transaction_id: paymentIntent.id,
-          payment_id: paymentIntent.id, // Store payment_id for webhook lookups
-          payment_intent_id: paymentIntent.id, // Explicitly include payment_intent_id
-          amount: (paymentIntent.amount / 100).toString(), // Convert from cents
-        });
-        return true;
-      } 
-      
-      // Handle other statuses
-      if (paymentIntent) {
-        const errorMsg = `Payment status: ${paymentIntent.status}`;
-        setError(errorMsg);
-        onPaymentError(new Error(errorMsg));
-      } else {
-        setError('Payment failed with unknown error');
-        onPaymentError(new Error('Payment failed with unknown error'));
+      if (confirmError) {
+        throw new Error(confirmError.message || 'Payment failed');
       }
-      
-      return false;
+
+      if (!paymentIntent || paymentIntent.status !== 'succeeded') {
+        throw new Error(paymentIntent ? `Payment status: ${paymentIntent.status}` : 'Payment failed');
+      }
+
+      onPaymentSuccess({
+        status: paymentIntent.status,
+        transaction_id: paymentIntent.id,
+        payment_id: paymentIntent.id,
+        payment_intent_id: paymentIntent.id,
+        amount: (paymentIntent.amount / 100).toString(),
+      });
+
+      return true;
     } catch (err: any) {
       setError(err.message || 'Payment failed');
       onPaymentError(err);
@@ -331,16 +291,15 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
     }
   };
 
-  // Expose the processPayment method to parent component
   React.useImperativeHandle(ref, () => ({
-    processPayment
+    processPayment,
   }), [processPayment]);
 
-  if (loading && !isFreeOrder) {
+  if (loading && !isFreeOrder && !isSmallOrder) {
     return (
       <div className="flex justify-center items-center p-4">
         <LoadingSpinner className="w-8 h-8" />
-        <span className="ml-2">Loading Stripe...</span>
+        <span className="ml-2">Loading secure card checkout...</span>
       </div>
     );
   }
@@ -349,97 +308,66 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
     return (
       <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-md">
         <p>Error: {error}</p>
-        <p className="mt-2">Please try another payment method or contact support.</p>
+        <p className="mt-2">Please review your payment details or contact support.</p>
+      </div>
+    );
+  }
+
+  if (isFreeOrder) {
+    return (
+      <div className="bg-green-50 border border-green-100 p-3 rounded-md">
+        <p className="font-bold text-green-700 inline-block mr-2">FREE ORDER</p>
+        <span className="text-green-700">No payment is required for this order.</span>
+      </div>
+    );
+  }
+
+  if (isSmallOrder) {
+    return (
+      <div className="bg-blue-50 border border-blue-100 p-3 rounded-md">
+        <p className="font-bold text-blue-700 inline-block mr-2">SMALL ORDER</p>
+        <span className="text-blue-700">This order will be completed without collecting card details.</span>
+      </div>
+    );
+  }
+
+  if (testMode) {
+    return (
+      <div className="space-y-4">
+        <div className="bg-yellow-50 border border-yellow-100 p-3 rounded-md">
+          <p className="font-bold text-yellow-700 inline-block mr-2">TEST MODE</p>
+          <span className="text-yellow-700">Payments are simulated in this environment.</span>
+        </div>
+        <div className="rounded-md border border-gray-200 p-4 bg-gray-50">
+          <p className="font-medium text-gray-900 mb-1">Card checkout only</p>
+          <p className="text-sm text-gray-600">Use Stripe test card `4242 4242 4242 4242` when testing.</p>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="stripe-checkout-container">
-      {/* Free order view */}
-      {isFreeOrder ? (
-        <div className="bg-green-50 border border-green-100 p-3 mb-4 rounded-md">
-          <p className="font-bold text-green-700 inline-block mr-2">FREE ORDER</p>
-          <span className="text-green-700">No payment required. Click the button below to complete your order.</span>
-        </div>
-      ) : isSmallOrder ? (
-        <div className="bg-blue-50 border border-blue-100 p-3 mb-4 rounded-md">
-          <p className="font-bold text-blue-700 inline-block mr-2">SMALL ORDER</p>
-          <span className="text-blue-700">Small orders are processed without requiring card details. Click the button below to complete your order.</span>
-        </div>
-      ) : testMode ? (
-        <div>
-          <div className="bg-yellow-50 border border-yellow-100 p-3 mb-4 rounded-md">
-            <p className="font-bold text-yellow-700 inline-block mr-2">TEST MODE</p>
-            <span className="text-yellow-700">Payments will be simulated without processing real cards.</span>
-          </div>
-          
-          <div className="mb-4">
-            <h3 className="font-medium mb-2">Enter your card details to complete your payment.</h3>
-          
-            {/* Card Number */}
-            <div className="mb-4">
-              <label className="block text-gray-700 text-sm font-medium mb-1">Card Number</label>
-              <input 
-                type="text"
-                defaultValue="4111 1111 1111 1111"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
-                placeholder="4111 1111 1111 1111 (Test Card)"
-                readOnly={processing}
-              />
-            </div>
-            
-            {/* Two columns for expiry and CVV */}
-            <div className="grid grid-cols-2 gap-4 mb-4">
-              <div>
-                <label className="block text-gray-700 text-sm font-medium mb-1">Expiration Date</label>
-                <input
-                  type="text"
-                  defaultValue="12/25"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
-                  placeholder="MM/YY"
-                  readOnly={processing}
-                />
-              </div>
-              <div>
-                <label className="block text-gray-700 text-sm font-medium mb-1">CVV</label>
-                <input
-                  type="text"
-                  defaultValue="123"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
-                  placeholder="123"
-                  readOnly={processing}
-                />
-              </div>
-            </div>
-          </div>
-          
-          {/* No submit button - parent will call processPayment */}
-          
-          {/* Processing indicator removed in favor of full-screen overlay */}
+    <div className="space-y-4">
+      <div className="rounded-md border border-gray-200 p-4 bg-gray-50">
+        <p className="font-medium text-gray-900 mb-1">Card checkout only</p>
+        <p className="text-sm text-gray-600">
+          V1 currently supports secure card payments only to ensure the order is finalized reliably.
+        </p>
+      </div>
+
+      {!clientSecret || !elements ? (
+        <div className="flex justify-center items-center p-4">
+          <LoadingSpinner className="w-8 h-8" />
+          <span className="ml-2">Preparing secure card form...</span>
         </div>
       ) : (
-        // Live mode with actual Stripe Elements
-        !elements ? (
-          <div className="flex justify-center items-center p-4">
-            <LoadingSpinner className="w-8 h-8" />
-            <span className="ml-2">Preparing checkout...</span>
-          </div>
-        ) : (
-          <div>
-            <div id="payment-element" ref={paymentElementRef} className="mb-6">
-              {/* Payment Element will be mounted here by the useEffect hook */}
-            </div>
-            
-            {/* No submit button - parent will call processPayment */}
-            
-            {/* Processing indicator removed in favor of full-screen overlay */}
-          </div>
-        )
+        <div className="rounded-md border border-gray-300 bg-white px-3 py-4">
+          <label className="block text-sm font-medium text-gray-700 mb-3">Card Information</label>
+          <div ref={cardElementRef} />
+        </div>
       )}
     </div>
   );
 });
 
-// Add display name for better debugging
 StripeCheckout.displayName = 'StripeCheckout';

--- a/src/ordering/components/payment/StripeCheckout.tsx
+++ b/src/ordering/components/payment/StripeCheckout.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import type { Stripe, StripeCardElement, StripeCardElementChangeEvent, StripeElements } from '@stripe/stripe-js';
 
 import { api } from '../../../shared/api/apiClient';
 import { LoadingSpinner } from '../../../shared/components/ui';
@@ -33,6 +34,23 @@ export interface StripeCheckoutRef {
   processPayment: () => Promise<boolean>;
 }
 
+declare global {
+  interface Window {
+    Stripe?: (publishableKey: string) => Stripe;
+  }
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message) return message;
+  }
+
+  return fallback;
+}
+
 export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckoutProps>((props, ref) => {
   const {
     amount,
@@ -46,9 +64,9 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
-  const [stripe, setStripe] = useState<any>(null);
-  const [elements, setElements] = useState<any>(null);
-  const [cardElement, setCardElement] = useState<any>(null);
+  const [stripe, setStripe] = useState<Stripe | null>(null);
+  const [elements, setElements] = useState<StripeElements | null>(null);
+  const [cardElement, setCardElement] = useState<StripeCardElement | null>(null);
   const [clientSecret, setClientSecret] = useState<string | null>(null);
   const [isFreeOrder, setIsFreeOrder] = useState(false);
   const [isSmallOrder, setIsSmallOrder] = useState(false);
@@ -74,8 +92,8 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
       return;
     }
 
-    if ((window as any).Stripe) {
-      setStripe((window as any).Stripe(publishableKey));
+    if (window.Stripe) {
+      setStripe(window.Stripe(publishableKey));
       setLoading(false);
       return;
     }
@@ -84,7 +102,13 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
     script.src = 'https://js.stripe.com/v3/';
     script.async = true;
     script.onload = () => {
-      setStripe((window as any).Stripe(publishableKey));
+      if (!window.Stripe) {
+        setError('Stripe.js loaded without initializing correctly');
+        setLoading(false);
+        return;
+      }
+
+      setStripe(window.Stripe(publishableKey));
       setLoading(false);
     };
     script.onerror = () => {
@@ -128,9 +152,10 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
         }
 
         setClientSecret(response.client_secret);
-      } catch (err: any) {
-        setError(err.message || 'Failed to create payment intent');
-        onPaymentError(err);
+      } catch (err: unknown) {
+        const message = errorMessage(err, 'Failed to create payment intent');
+        setError(message);
+        onPaymentError(err instanceof Error ? err : new Error(message));
       }
     };
 
@@ -158,19 +183,20 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
       });
 
       setElements(elementsInstance);
-    } catch (err: any) {
-      setError(err.message || 'Failed to initialize Stripe Elements');
-      onPaymentError(err);
+    } catch (err: unknown) {
+      const message = errorMessage(err, 'Failed to initialize Stripe Elements');
+      setError(message);
+      onPaymentError(err instanceof Error ? err : new Error(message));
     }
   }, [error, isFreeOrder, isSmallOrder, onPaymentError, stripe, testMode]);
 
   useEffect(() => {
-    if (testMode || !elements || !cardElementRef.current || cardElementMounted.current || isFreeOrder || isSmallOrder) {
+    if (testMode || !elements || !clientSecret || !cardElementRef.current || cardElementMounted.current || isFreeOrder || isSmallOrder) {
       return;
     }
 
     cardElementMounted.current = true;
-    let card: any = null;
+    let card: StripeCardElement | null = null;
 
     try {
       card = elements.create('card', {
@@ -192,16 +218,17 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
       card.mount(cardElementRef.current);
       setCardElement(card);
 
-      card.on('change', (event: any) => {
+      card.on('change', (event: StripeCardElementChangeEvent) => {
         if (event.error) {
           setError(event.error.message);
         } else {
           setError(null);
         }
       });
-    } catch (err: any) {
-      setError(err.message || 'Failed to mount card input');
-      onPaymentError(err);
+    } catch (err: unknown) {
+      const message = errorMessage(err, 'Failed to mount card input');
+      setError(message);
+      onPaymentError(err instanceof Error ? err : new Error(message));
     }
 
     return () => {
@@ -214,7 +241,7 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
       }
       cardElementMounted.current = false;
     };
-  }, [elements, isFreeOrder, isSmallOrder, onPaymentError, testMode]);
+  }, [clientSecret, elements, isFreeOrder, isSmallOrder, onPaymentError, testMode]);
 
   const processPayment = async (): Promise<boolean> => {
     if (processing) return false;
@@ -282,9 +309,10 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
       });
 
       return true;
-    } catch (err: any) {
-      setError(err.message || 'Payment failed');
-      onPaymentError(err);
+    } catch (err: unknown) {
+      const message = errorMessage(err, 'Payment failed');
+      setError(message);
+      onPaymentError(err instanceof Error ? err : new Error(message));
       return false;
     } finally {
       setProcessing(false);

--- a/src/ordering/components/payment/StripeCheckout.tsx
+++ b/src/ordering/components/payment/StripeCheckout.tsx
@@ -290,6 +290,7 @@ export const StripeCheckout = React.forwardRef<StripeCheckoutRef, StripeCheckout
         payment_method: {
           card: cardElement,
         },
+        return_url: `${window.location.origin}/checkout/return`,
       });
 
       if (confirmError) {

--- a/src/ordering/store/orderStore.ts
+++ b/src/ordering/store/orderStore.ts
@@ -30,6 +30,19 @@ export interface OrdersMetadata {
   total_pages: number;
 }
 
+function earliestAdvanceNoticePickupTime(items: CartItem[]): string | undefined {
+  const maxAdvanceNoticeHours = Math.max(
+    0,
+    ...items.map((item) => item.advance_notice_hours ?? 0)
+  );
+
+  if (maxAdvanceNoticeHours < 24) return undefined;
+
+  // Add a small buffer so the backend's "now + notice" validation cannot fail
+  // because a few seconds elapsed between building the payload and validation.
+  return new Date(Date.now() + (maxAdvanceNoticeHours * 60 + 5) * 60 * 1000).toISOString();
+}
+
 export interface OrderQueryParams {
   page?: number;
   perPage?: number;
@@ -755,6 +768,7 @@ export const useOrderStore = create<OrderStore>()(
           // Extract staffOrderParams from paymentDetails if present
           const staffOrderParams = paymentDetails?.staffOrderParams || {};
           
+          const advanceNoticePickupTime = earliestAdvanceNoticePickupTime(items);
           const payload = {
             order: {
               items: foodItems,
@@ -769,6 +783,7 @@ export const useOrderStore = create<OrderStore>()(
               vip_code: vipCode,
               staff_modal: staffModal,
               payment_details: paymentDetails,
+              estimated_pickup_time: advanceNoticePickupTime,
               // Include location_id if provided
               location_id: locationId,
               // Include staff order parameters, especially created_by_staff_id
@@ -789,6 +804,7 @@ export const useOrderStore = create<OrderStore>()(
             contact_email: contactEmail || '',
             transaction_id: transactionId || '',
             payment_method: paymentMethod,
+            estimated_pickup_time: advanceNoticePickupTime,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),
           };

--- a/src/ordering/store/orderStore.ts
+++ b/src/ordering/store/orderStore.ts
@@ -714,16 +714,13 @@ export const useOrderStore = create<OrderStore>()(
       ) => {
         // Guard against duplicate submit taps/clicks
         if (get().isPlacingOrder) {
-          return {
-            id: `duplicate-${Date.now()}`,
-            status: 'error',
-            error: 'Order is already being submitted. Please wait.'
-          } as any;
+          throw new Error('Order is already being submitted. Please wait.');
         }
 
         // Skip setting loading state since we're showing a payment processing overlay already
         // This avoids unnecessary UI updates that can slow down the process
         set({ error: null, isPlacingOrder: true });
+        const tempId = `temp-${Date.now()}`;
         try {
           // Separate food vs merchandise
           const foodItems = [];
@@ -737,6 +734,7 @@ export const useOrderStore = create<OrderStore>()(
                 name: item.name,
                 quantity: item.quantity,
                 price: item.price,
+                merchandise_variant_id: item.variant_id,
                 variant_id: item.variant_id,
                 size: item.size,
                 color: item.color,
@@ -779,7 +777,6 @@ export const useOrderStore = create<OrderStore>()(
           };
 
           // Optimistic UI: create a temporary order
-          const tempId = `temp-${Date.now()}`;
           const optimisticOrder: Order = {
             id: tempId,
             status: 'pending',
@@ -820,11 +817,7 @@ export const useOrderStore = create<OrderStore>()(
             orders: get().orders.filter(order => order.id !== tempId)
           });
           console.error('Failed to create order:', err);
-          return {
-            id: `error-${Date.now()}`,
-            status: 'error',
-            error: err.message
-          } as any;
+          throw err;
         } finally {
           set({ isPlacingOrder: false });
         }

--- a/src/ordering/types/order.ts
+++ b/src/ordering/types/order.ts
@@ -8,7 +8,7 @@ export interface OrderItem {
   quantity: number;
   options?: string[];
   notes?: string;
-  customizations?: any[] | Record<string, any>;
+  customizations?: unknown[] | Record<string, unknown>;
 }
 
 export interface OrderPayment {
@@ -48,11 +48,13 @@ export interface Order {
   contact_phone?: string;
   contact_email?: string;
   pickup_time?: string;
+  estimated_pickup_time?: string;
   payment_method?: string;
   payment_status?: string;
   total_refunded?: number;
   order_payments?: OrderPayment[];
   location_name?: string;
+  location_address?: string;
   transaction_id?: string;
   restaurant_id?: string;
   staff_created?: boolean; // Flag to indicate if order was created by staff

--- a/src/ordering/utils/pendingCheckout.ts
+++ b/src/ordering/utils/pendingCheckout.ts
@@ -1,0 +1,68 @@
+import type { CartItem } from '../store/orderStore';
+
+const STORAGE_KEY = 'hafaloha_pending_checkout_v1';
+const MAX_AGE_MS = 1000 * 60 * 60 * 4;
+
+export interface PendingCheckoutFormData {
+  name: string;
+  email: string;
+  phone: string;
+  specialInstructions: string;
+  promoCode: string;
+  vipCode: string;
+}
+
+export interface PendingCheckoutDraft {
+  version: 1;
+  createdAt: string;
+  restaurantId: string;
+  cartItems: CartItem[];
+  finalTotal: number;
+  formData: PendingCheckoutFormData;
+  locationId?: number;
+}
+
+export function savePendingCheckoutDraft(draft: Omit<PendingCheckoutDraft, 'version' | 'createdAt'>) {
+  if (typeof window === 'undefined') return;
+
+  const payload: PendingCheckoutDraft = {
+    ...draft,
+    version: 1,
+    createdAt: new Date().toISOString(),
+  };
+
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function loadPendingCheckoutDraft(): PendingCheckoutDraft | null {
+  if (typeof window === 'undefined') return null;
+
+  const raw = sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as PendingCheckoutDraft;
+    const createdAtMs = new Date(parsed.createdAt).getTime();
+
+    if (!createdAtMs || Number.isNaN(createdAtMs)) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+
+    if (Date.now() - createdAtMs > MAX_AGE_MS) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.error('Failed to parse pending checkout draft:', error);
+    sessionStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+}
+
+export function clearPendingCheckoutDraft() {
+  if (typeof window === 'undefined') return;
+  sessionStorage.removeItem(STORAGE_KEY);
+}

--- a/src/ordering/utils/pendingCheckout.ts
+++ b/src/ordering/utils/pendingCheckout.ts
@@ -8,7 +8,6 @@ export interface PendingCheckoutFormData {
   email: string;
   phone: string;
   specialInstructions: string;
-  promoCode: string;
   vipCode: string;
 }
 

--- a/src/shared/api/endpoints/auth.ts
+++ b/src/shared/api/endpoints/auth.ts
@@ -45,21 +45,23 @@ export async function resendVerificationCode(): Promise<{ message: string }> {
  * Request a password reset for a user
  */
 export async function requestPasswordReset(email: string): Promise<{ message: string }> {
-  return api.post<{ message: string }>('/password/reset', { email });
+  return api.post<{ message: string }>('/password/forgot', { email });
 }
 
 /**
  * Reset a user's password with a token
  */
 export async function resetPassword(
+  email: string,
   token: string,
   password: string,
   passwordConfirmation: string
-): Promise<{ message: string }> {
-  return api.post<{ message: string }>('/password/update', {
+): Promise<AuthResponse> {
+  return api.patch<AuthResponse>('/password/reset', {
+    email,
     token,
-    password,
-    password_confirmation: passwordConfirmation,
+    new_password: password,
+    new_password_confirmation: passwordConfirmation,
   });
 }
 

--- a/src/shared/api/endpoints/stripe.ts
+++ b/src/shared/api/endpoints/stripe.ts
@@ -15,6 +15,17 @@ interface PaymentIntentDetailsResponse {
   payment_method_types?: string[];
 }
 
+interface OrderByTransactionResponse {
+  id: string;
+  [key: string]: unknown;
+}
+
+type ApiErrorLike = {
+  response?: {
+    status?: number;
+  };
+};
+
 /**
  * API client for Stripe-related endpoints
  */
@@ -63,5 +74,26 @@ export const stripeApi = {
       payment_intent_id: paymentIntentId,
     });
     return response;
+  },
+
+  /**
+   * Find an existing order by Stripe payment intent/transaction ID.
+   * Used by checkout recovery before re-submitting an already-paid order.
+   */
+  findOrderByTransaction: async (
+    transactionId: string,
+    restaurantId: string
+  ): Promise<OrderByTransactionResponse | null> => {
+    try {
+      const response = await api.get<OrderByTransactionResponse>('/orders/by_transaction', {
+        transaction_id: transactionId,
+        restaurant_id: restaurantId,
+      }, { silent: true });
+      return response;
+    } catch (error: unknown) {
+      const apiError = error as ApiErrorLike;
+      if (apiError.response?.status === 404) return null;
+      throw error;
+    }
   },
 };

--- a/src/shared/api/endpoints/stripe.ts
+++ b/src/shared/api/endpoints/stripe.ts
@@ -7,8 +7,12 @@ interface PaymentIntentResponse {
 interface PaymentIntentDetailsResponse {
   id: string;
   amount: number;
+  amount_received?: number;
   status: string;
   client_secret: string;
+  currency?: string;
+  payment_method?: string;
+  payment_method_types?: string[];
 }
 
 /**
@@ -37,8 +41,13 @@ export const stripeApi = {
    * @param id - The ID of the payment intent
    * @returns A promise that resolves to the payment intent details
    */
-  getPaymentIntent: async (id: string): Promise<PaymentIntentDetailsResponse> => {
-    const response = await api.get<PaymentIntentDetailsResponse>(`/stripe/payment_intent/${id}`);
+  getPaymentIntent: async (
+    id: string,
+    restaurantId: string
+  ): Promise<PaymentIntentDetailsResponse> => {
+    const response = await api.get<PaymentIntentDetailsResponse>(`/stripe/payment_intent/${id}`, {
+      restaurant_id: restaurantId,
+    });
     return response;
   },
 

--- a/src/shared/api/endpoints/stripe.ts
+++ b/src/shared/api/endpoints/stripe.ts
@@ -15,7 +15,7 @@ interface PaymentIntentDetailsResponse {
   payment_method_types?: string[];
 }
 
-interface OrderByTransactionResponse {
+export interface OrderByTransactionResponse {
   id: string;
   [key: string]: unknown;
 }
@@ -68,10 +68,12 @@ export const stripeApi = {
    * @returns A promise that resolves to the confirmed payment intent
    */
   confirmPaymentIntent: async (
-    paymentIntentId: string
+    paymentIntentId: string,
+    restaurantId: string = localStorage.getItem('restaurant_id') || import.meta.env.VITE_RESTAURANT_ID || '1'
   ): Promise<PaymentIntentDetailsResponse> => {
     const response = await api.post<PaymentIntentDetailsResponse>('/stripe/confirm_intent', {
       payment_intent_id: paymentIntentId,
+      restaurant_id: restaurantId,
     });
     return response;
   },
@@ -82,12 +84,14 @@ export const stripeApi = {
    */
   findOrderByTransaction: async (
     transactionId: string,
-    restaurantId: string
+    restaurantId: string,
+    paymentIntentClientSecret: string
   ): Promise<OrderByTransactionResponse | null> => {
     try {
       const response = await api.get<OrderByTransactionResponse>('/orders/by_transaction', {
         transaction_id: transactionId,
         restaurant_id: restaurantId,
+        payment_intent_client_secret: paymentIntentClientSecret,
       }, { silent: true });
       return response;
     } catch (error: unknown) {

--- a/src/shared/api/endpoints/stripe.ts
+++ b/src/shared/api/endpoints/stripe.ts
@@ -88,7 +88,7 @@ export const stripeApi = {
     paymentIntentClientSecret: string
   ): Promise<OrderByTransactionResponse | null> => {
     try {
-      const response = await api.get<OrderByTransactionResponse>('/orders/by_transaction', {
+      const response = await api.post<OrderByTransactionResponse>('/orders/by_transaction', {
         transaction_id: transactionId,
         restaurant_id: restaurantId,
         payment_intent_client_secret: paymentIntentClientSecret,

--- a/src/shared/components/analytics/PostHogProvider.tsx
+++ b/src/shared/components/analytics/PostHogProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import posthog from 'posthog-js';
 import { PostHogProvider as OriginalPostHogProvider } from 'posthog-js/react';
 import { useAuthStore } from '../../auth';
@@ -10,7 +10,7 @@ const posthogOptions = {
   autocapture: true,
   capture_pageview: true,
   capture_pageleave: true,
-  disable_session_recording: false, // Enable session recording
+  disable_session_recording: true, // Avoid recording checkout/admin PII in this legacy app
   // Add safe localStorage handling for incognito mode
   persistence: "memory" as const, // Use memory persistence in incognito mode
   bootstrap: {
@@ -24,29 +24,19 @@ const isIncognitoMode = () => {
     localStorage.setItem('test', 'test');
     localStorage.removeItem('test');
     return false;
-  } catch (e) {
+  } catch {
     return true;
   }
 };
 
 // Create wrapper component to handle restaurant context
 const PostHogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  // Use state to track if we've initialized safely
-  const [isInitialized, setIsInitialized] = useState(false);
-  
-  // Only use these hooks if we're not in incognito mode
-  const authStore = !isIncognitoMode() ? useAuthStore() : { user: null };
-  const restaurantStore = !isIncognitoMode() ? useRestaurantStore() : { restaurant: null };
-  
-  const { user } = authStore;
-  const { restaurant } = restaurantStore;
+  const { user } = useAuthStore();
+  const { restaurant } = useRestaurantStore();
   
   // Initialize PostHog safely
   useEffect(() => {
     try {
-      // Mark as initialized
-      setIsInitialized(true);
-      
       // In incognito mode, use an anonymous ID
       const inIncognito = isIncognitoMode();
       if (inIncognito) {
@@ -77,8 +67,7 @@ const PostHogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) 
           vip_enabled: restaurant.vip_enabled
         });
       }
-    } catch (error) {
-      // Continue rendering the app even if PostHog fails
+    } catch {
       // Continue rendering the app even if PostHog fails
     }
   }, [user, restaurant]);

--- a/src/shared/utils/simpleSpreadsheet.ts
+++ b/src/shared/utils/simpleSpreadsheet.ts
@@ -11,31 +11,71 @@ interface Workbook {
   sheets: WorkbookSheet[];
 }
 
-function escapeCsvValue(value: SpreadsheetValue): string {
+function escapeXml(value: SpreadsheetValue): string {
   const normalized = value instanceof Date ? value.toISOString() : value ?? '';
-  const stringValue = String(normalized);
-
-  if (/[",\n\r]/.test(stringValue)) {
-    return `"${stringValue.replace(/"/g, '""')}"`;
-  }
-
-  return stringValue;
+  return String(normalized)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
 }
 
-function worksheetToCsv(rows: Worksheet): string {
-  if (!rows.length) return '';
+function spreadsheetType(value: SpreadsheetValue): 'String' | 'Number' | 'Boolean' | 'DateTime' {
+  if (value instanceof Date) return 'DateTime';
+  if (typeof value === 'number') return 'Number';
+  if (typeof value === 'boolean') return 'Boolean';
+  return 'String';
+}
 
-  const headers = Array.from(
+function cellXml(value: SpreadsheetValue): string {
+  const type = spreadsheetType(value);
+  const normalized = typeof value === 'boolean' ? (value ? '1' : '0') : value;
+  return `<Cell><Data ss:Type="${type}">${escapeXml(normalized)}</Data></Cell>`;
+}
+
+function worksheetHeaders(rows: Worksheet): string[] {
+  return Array.from(
     rows.reduce<Set<string>>((set, row) => {
       Object.keys(row).forEach((key) => set.add(key));
       return set;
     }, new Set())
   );
+}
 
-  return [
-    headers.map(escapeCsvValue).join(','),
-    ...rows.map((row) => headers.map((header) => escapeCsvValue(row[header])).join(',')),
-  ].join('\n');
+function sanitizeSheetName(name: string, index: number): string {
+  const sanitized = name
+    .replace(/[\\/?*:]/g, ' ')
+    .replace(/\[/g, ' ')
+    .replace(/\]/g, ' ')
+    .trim() || `Sheet ${index + 1}`;
+  return sanitized.slice(0, 31);
+}
+
+function worksheetToXml(sheet: WorkbookSheet, index: number): string {
+  const headers = worksheetHeaders(sheet.rows);
+  const headerRow = `<Row>${headers.map(cellXml).join('')}</Row>`;
+  const dataRows = sheet.rows
+    .map((row) => `<Row>${headers.map((header) => cellXml(row[header])).join('')}</Row>`)
+    .join('');
+
+  return `
+    <Worksheet ss:Name="${escapeXml(sanitizeSheetName(sheet.name, index))}">
+      <Table>${headerRow}${dataRows}</Table>
+    </Worksheet>`;
+}
+
+function workbookToSpreadsheetXml(workbook: Workbook): string {
+  const sheets = workbook.sheets.length ? workbook.sheets : [{ name: 'Sheet 1', rows: [] }];
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+  xmlns:o="urn:schemas-microsoft-com:office:office"
+  xmlns:x="urn:schemas-microsoft-com:office:excel"
+  xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
+  ${sheets.map(worksheetToXml).join('')}
+</Workbook>`;
 }
 
 export const utils = {
@@ -53,15 +93,12 @@ export const utils = {
 };
 
 export function writeFile(workbook: Workbook, filename: string): void {
-  const csv = workbook.sheets
-    .map((sheet) => [`# ${sheet.name}`, worksheetToCsv(sheet.rows)].filter(Boolean).join('\n'))
-    .join('\n\n');
-
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const xml = workbookToSpreadsheetXml(workbook);
+  const blob = new Blob([xml], { type: 'application/vnd.ms-excel;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
   link.href = url;
-  link.download = filename.replace(/\.xlsx$/i, '.csv');
+  link.download = filename.replace(/\.(xlsx|csv)$/i, '.xls');
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);

--- a/src/shared/utils/simpleSpreadsheet.ts
+++ b/src/shared/utils/simpleSpreadsheet.ts
@@ -94,11 +94,11 @@ export const utils = {
 
 export function writeFile(workbook: Workbook, filename: string): void {
   const xml = workbookToSpreadsheetXml(workbook);
-  const blob = new Blob([xml], { type: 'application/vnd.ms-excel;charset=utf-8;' });
+  const blob = new Blob([xml], { type: 'application/xml;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
   link.href = url;
-  link.download = filename.replace(/\.(xlsx|csv)$/i, '.xls');
+  link.download = filename.replace(/\.(xlsx|xls|csv)$/i, '.xml');
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);

--- a/src/shared/utils/simpleSpreadsheet.ts
+++ b/src/shared/utils/simpleSpreadsheet.ts
@@ -11,6 +11,16 @@ interface Workbook {
   sheets: WorkbookSheet[];
 }
 
+interface ZipEntry {
+  name: string;
+  data: Uint8Array;
+  crc32: number;
+  offset: number;
+}
+
+const XLSX_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+const encoder = new TextEncoder();
+
 function escapeXml(value: SpreadsheetValue): string {
   const normalized = value instanceof Date ? value.toISOString() : value ?? '';
   return String(normalized)
@@ -21,17 +31,10 @@ function escapeXml(value: SpreadsheetValue): string {
     .replace(/'/g, '&apos;');
 }
 
-function spreadsheetType(value: SpreadsheetValue): 'String' | 'Number' | 'Boolean' | 'DateTime' {
-  if (value instanceof Date) return 'DateTime';
-  if (typeof value === 'number') return 'Number';
-  if (typeof value === 'boolean') return 'Boolean';
-  return 'String';
-}
-
-function cellXml(value: SpreadsheetValue): string {
-  const type = spreadsheetType(value);
-  const normalized = typeof value === 'boolean' ? (value ? '1' : '0') : value;
-  return `<Cell><Data ss:Type="${type}">${escapeXml(normalized)}</Data></Cell>`;
+function textNode(value: SpreadsheetValue): string {
+  const escaped = escapeXml(value);
+  const preserveWhitespace = /^\s|\s$/.test(escaped);
+  return `<t${preserveWhitespace ? ' xml:space="preserve"' : ''}>${escaped}</t>`;
 }
 
 function worksheetHeaders(rows: Worksheet): string[] {
@@ -52,30 +55,243 @@ function sanitizeSheetName(name: string, index: number): string {
   return sanitized.slice(0, 31);
 }
 
-function worksheetToXml(sheet: WorkbookSheet, index: number): string {
-  const headers = worksheetHeaders(sheet.rows);
-  const headerRow = `<Row>${headers.map(cellXml).join('')}</Row>`;
-  const dataRows = sheet.rows
-    .map((row) => `<Row>${headers.map((header) => cellXml(row[header])).join('')}</Row>`)
-    .join('');
+function columnName(index: number): string {
+  let column = '';
+  let current = index + 1;
 
-  return `
-    <Worksheet ss:Name="${escapeXml(sanitizeSheetName(sheet.name, index))}">
-      <Table>${headerRow}${dataRows}</Table>
-    </Worksheet>`;
+  while (current > 0) {
+    const remainder = (current - 1) % 26;
+    column = String.fromCharCode(65 + remainder) + column;
+    current = Math.floor((current - 1) / 26);
+  }
+
+  return column;
 }
 
-function workbookToSpreadsheetXml(workbook: Workbook): string {
-  const sheets = workbook.sheets.length ? workbook.sheets : [{ name: 'Sheet 1', rows: [] }];
+function cellReference(columnIndex: number, rowIndex: number): string {
+  return `${columnName(columnIndex)}${rowIndex}`;
+}
 
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<?mso-application progid="Excel.Sheet"?>
-<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
-  xmlns:o="urn:schemas-microsoft-com:office:office"
-  xmlns:x="urn:schemas-microsoft-com:office:excel"
-  xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
-  ${sheets.map(worksheetToXml).join('')}
-</Workbook>`;
+function cellXml(value: SpreadsheetValue, reference: string): string {
+  if (value === null || value === undefined || value === '') {
+    return `<c r="${reference}"/>`;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `<c r="${reference}"><v>${value}</v></c>`;
+  }
+
+  if (typeof value === 'boolean') {
+    return `<c r="${reference}" t="b"><v>${value ? 1 : 0}</v></c>`;
+  }
+
+  return `<c r="${reference}" t="inlineStr"><is>${textNode(value)}</is></c>`;
+}
+
+function rowXml(values: SpreadsheetValue[], rowIndex: number): string {
+  const cells = values
+    .map((value, columnIndex) => cellXml(value, cellReference(columnIndex, rowIndex)))
+    .join('');
+  return `<row r="${rowIndex}">${cells}</row>`;
+}
+
+function worksheetToXml(sheet: WorkbookSheet): string {
+  const headers = worksheetHeaders(sheet.rows);
+  const rows: string[] = [];
+
+  if (headers.length > 0) {
+    rows.push(rowXml(headers, 1));
+    sheet.rows.forEach((row, index) => {
+      rows.push(rowXml(headers.map((header) => row[header]), index + 2));
+    });
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>${rows.join('')}</sheetData>
+</worksheet>`;
+}
+
+function workbookToXml(sheets: WorkbookSheet[]): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    ${sheets.map((sheet, index) => `<sheet name="${escapeXml(sanitizeSheetName(sheet.name, index))}" sheetId="${index + 1}" r:id="rId${index + 1}"/>`).join('')}
+  </sheets>
+</workbook>`;
+}
+
+function workbookRelsToXml(sheets: WorkbookSheet[]): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  ${sheets.map((_, index) => `<Relationship Id="rId${index + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet${index + 1}.xml"/>`).join('')}
+</Relationships>`;
+}
+
+function rootRelsToXml(): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`;
+}
+
+function contentTypesToXml(sheets: WorkbookSheet[]): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  ${sheets.map((_, index) => `<Override PartName="/xl/worksheets/sheet${index + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`).join('')}
+</Types>`;
+}
+
+function workbookFiles(workbook: Workbook): Array<{ name: string; content: string }> {
+  const sheets = workbook.sheets.length ? workbook.sheets : [{ name: 'Sheet 1', rows: [] }];
+  return [
+    { name: '[Content_Types].xml', content: contentTypesToXml(sheets) },
+    { name: '_rels/.rels', content: rootRelsToXml() },
+    { name: 'xl/workbook.xml', content: workbookToXml(sheets) },
+    { name: 'xl/_rels/workbook.xml.rels', content: workbookRelsToXml(sheets) },
+    ...sheets.map((sheet, index) => ({
+      name: `xl/worksheets/sheet${index + 1}.xml`,
+      content: worksheetToXml(sheet),
+    })),
+  ];
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function dosDateTime(date: Date): { date: number; time: number } {
+  const year = Math.max(date.getFullYear(), 1980);
+  return {
+    date: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate(),
+    time: (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2),
+  };
+}
+
+function littleEndianBytes(value: number, byteLength: 2 | 4): Uint8Array {
+  const bytes = new Uint8Array(byteLength);
+  const view = new DataView(bytes.buffer);
+
+  if (byteLength === 2) {
+    view.setUint16(0, value, true);
+  } else {
+    view.setUint32(0, value, true);
+  }
+
+  return bytes;
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+  const totalLength = parts.reduce((sum, part) => sum + part.length, 0);
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+
+  parts.forEach((part) => {
+    combined.set(part, offset);
+    offset += part.length;
+  });
+
+  return combined;
+}
+
+function localFileHeader(entry: ZipEntry, modTime: number, modDate: number): Uint8Array {
+  const name = encoder.encode(entry.name);
+  return concatBytes([
+    littleEndianBytes(0x04034b50, 4),
+    littleEndianBytes(20, 2),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(modTime, 2),
+    littleEndianBytes(modDate, 2),
+    littleEndianBytes(entry.crc32, 4),
+    littleEndianBytes(entry.data.length, 4),
+    littleEndianBytes(entry.data.length, 4),
+    littleEndianBytes(name.length, 2),
+    littleEndianBytes(0, 2),
+    name,
+  ]);
+}
+
+function centralDirectoryHeader(entry: ZipEntry, modTime: number, modDate: number): Uint8Array {
+  const name = encoder.encode(entry.name);
+  return concatBytes([
+    littleEndianBytes(0x02014b50, 4),
+    littleEndianBytes(20, 2),
+    littleEndianBytes(20, 2),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(modTime, 2),
+    littleEndianBytes(modDate, 2),
+    littleEndianBytes(entry.crc32, 4),
+    littleEndianBytes(entry.data.length, 4),
+    littleEndianBytes(entry.data.length, 4),
+    littleEndianBytes(name.length, 2),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(0, 4),
+    littleEndianBytes(entry.offset, 4),
+    name,
+  ]);
+}
+
+function endOfCentralDirectory(entryCount: number, centralDirectorySize: number, centralDirectoryOffset: number): Uint8Array {
+  return concatBytes([
+    littleEndianBytes(0x06054b50, 4),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(0, 2),
+    littleEndianBytes(entryCount, 2),
+    littleEndianBytes(entryCount, 2),
+    littleEndianBytes(centralDirectorySize, 4),
+    littleEndianBytes(centralDirectoryOffset, 4),
+    littleEndianBytes(0, 2),
+  ]);
+}
+
+function workbookToXlsxBlob(workbook: Workbook): Blob {
+  const { date, time } = dosDateTime(new Date());
+  const entries: ZipEntry[] = workbookFiles(workbook).map(({ name, content }) => {
+    const data = encoder.encode(content);
+    return { name, data, crc32: crc32(data), offset: 0 };
+  });
+
+  const localParts: Uint8Array[] = [];
+  let offset = 0;
+
+  entries.forEach((entry) => {
+    entry.offset = offset;
+    const header = localFileHeader(entry, time, date);
+    localParts.push(header, entry.data);
+    offset += header.length + entry.data.length;
+  });
+
+  const centralDirectoryOffset = offset;
+  const centralParts = entries.map((entry) => centralDirectoryHeader(entry, time, date));
+  const centralDirectorySize = centralParts.reduce((sum, part) => sum + part.length, 0);
+  const eocd = endOfCentralDirectory(entries.length, centralDirectorySize, centralDirectoryOffset);
+
+  return new Blob([...localParts, ...centralParts, eocd], { type: XLSX_MIME_TYPE });
+}
+
+function normalizeXlsxFilename(filename: string): string {
+  if (/\.(xlsx|xls|csv|xml)$/i.test(filename)) {
+    return filename.replace(/\.(xlsx|xls|csv|xml)$/i, '.xlsx');
+  }
+
+  return `${filename}.xlsx`;
 }
 
 export const utils = {
@@ -93,12 +309,11 @@ export const utils = {
 };
 
 export function writeFile(workbook: Workbook, filename: string): void {
-  const xml = workbookToSpreadsheetXml(workbook);
-  const blob = new Blob([xml], { type: 'application/xml;charset=utf-8;' });
+  const blob = workbookToXlsxBlob(workbook);
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
   link.href = url;
-  link.download = filename.replace(/\.(xlsx|xls|csv)$/i, '.xml');
+  link.download = normalizeXlsxFilename(filename);
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);

--- a/src/shared/utils/simpleSpreadsheet.ts
+++ b/src/shared/utils/simpleSpreadsheet.ts
@@ -21,9 +21,26 @@ interface ZipEntry {
 const XLSX_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 const encoder = new TextEncoder();
 
+function isValidXmlTextCodePoint(codePoint: number): boolean {
+  return codePoint === 0x09 ||
+    codePoint === 0x0a ||
+    codePoint === 0x0d ||
+    (codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+    (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+    (codePoint >= 0x10000 && codePoint <= 0x10ffff);
+}
+
+function sanitizeXmlText(value: string): string {
+  // XML 1.0 forbids most C0 control characters. Strip them so one bad
+  // report value cannot make the generated XLSX unreadable.
+  return Array.from(value)
+    .filter((character) => isValidXmlTextCodePoint(character.codePointAt(0) || 0))
+    .join('');
+}
+
 function escapeXml(value: SpreadsheetValue): string {
   const normalized = value instanceof Date ? value.toISOString() : value ?? '';
-  return String(normalized)
+  return sanitizeXmlText(String(normalized))
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/src/shared/utils/simpleSpreadsheet.ts
+++ b/src/shared/utils/simpleSpreadsheet.ts
@@ -1,0 +1,69 @@
+type SpreadsheetValue = string | number | boolean | null | undefined | Date;
+type SpreadsheetRow = Record<string, SpreadsheetValue>;
+type Worksheet = SpreadsheetRow[];
+
+interface WorkbookSheet {
+  name: string;
+  rows: Worksheet;
+}
+
+interface Workbook {
+  sheets: WorkbookSheet[];
+}
+
+function escapeCsvValue(value: SpreadsheetValue): string {
+  const normalized = value instanceof Date ? value.toISOString() : value ?? '';
+  const stringValue = String(normalized);
+
+  if (/[",\n\r]/.test(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+}
+
+function worksheetToCsv(rows: Worksheet): string {
+  if (!rows.length) return '';
+
+  const headers = Array.from(
+    rows.reduce<Set<string>>((set, row) => {
+      Object.keys(row).forEach((key) => set.add(key));
+      return set;
+    }, new Set())
+  );
+
+  return [
+    headers.map(escapeCsvValue).join(','),
+    ...rows.map((row) => headers.map((header) => escapeCsvValue(row[header])).join(',')),
+  ].join('\n');
+}
+
+export const utils = {
+  book_new(): Workbook {
+    return { sheets: [] };
+  },
+
+  json_to_sheet(rows: SpreadsheetRow[]): Worksheet {
+    return rows;
+  },
+
+  book_append_sheet(workbook: Workbook, worksheet: Worksheet, name: string): void {
+    workbook.sheets.push({ name, rows: worksheet });
+  },
+};
+
+export function writeFile(workbook: Workbook, filename: string): void {
+  const csv = workbook.sheets
+    .map((sheet) => [`# ${sheet.name}`, worksheetToCsv(sheet.rows)].filter(Boolean).join('\n'))
+    .join('\n\n');
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename.replace(/\.xlsx$/i, '.csv');
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- Add Stripe checkout draft persistence/recovery and a checkout return route for paid-order recovery.
- Send merchandise variant IDs through order creation and keep confirmation pages reload-safe via `/orders/:id`.
- Replace dynamic Tailwind color classes with static classes and disable PostHog session recording for the legacy app.
- Fix stale password-reset API helper paths.
- Remove vulnerable `xlsx` dependency and replace report exports with an internal CSV-backed spreadsheet utility.

## Verification
- `npm run build`
- `npm audit --omit=dev`
- `npx eslint src/shared/api/endpoints/auth.ts src/ordering/components/CheckoutReturn.tsx src/ordering/utils/pendingCheckout.ts src/shared/api/endpoints/stripe.ts src/ordering/components/payment/PaymentBaseStyles.tsx src/shared/components/analytics/PostHogProvider.tsx src/ordering/components/CheckoutPage.tsx src/ordering/components/OrderConfirmation.tsx src/shared/utils/simpleSpreadsheet.ts --quiet`
- `git diff --check`

Note: full-project lint remains noisy from existing legacy issues; this PR keeps the new/critical touched subset clean and verifies the production build.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Stripe checkout path with draft persistence/recovery via `sessionStorage`, introduces a `/checkout/return` route for post-3DS and network-failure recovery, replaces the vulnerable `xlsx` dependency with a hand-rolled OOXML+ZIP generator, fixes stale password-reset API paths, and replaces dynamic Tailwind color interpolation with static class names. The Stripe integration is also migrated from the Payment Element to the Card Element API.

- **Checkout recovery**: `pendingCheckout.ts` saves cart/form state before Stripe redirect; `CheckoutReturn.tsx` uses `stripeApi.findOrderByTransaction` to de-duplicate before re-submitting, guarded by the payment-intent client secret.
- **XLSX replacement**: `simpleSpreadsheet.ts` implements a from-scratch OOXML ZIP writer (uncompressed/stored method) with CRC32, proper column-letter generation, and XML sanitization.
- **Auth fix**: `requestPasswordReset` now POSTs to `/password/forgot`; `resetPassword` is patched to `/password/reset` and accepts `email` + `new_password` fields to match the backend API.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the checkout recovery and Stripe Card Element rewrite are structurally sound and the previously flagged bugs (blank card form, conditional hook call) are fixed in this PR.

The duplicate-order risk on network failure (already flagged in a prior round) remains — CheckoutReturn re-submits if findOrderByTransaction skips the lookup path, and the backend idempotency enforcement on transaction_id is the only guard. All other changes are well-bounded: the XLSX generator produces correct multi-sheet workbooks, the auth path fixes are straightforward, and the Stripe effect sequencing is correct.

src/ordering/components/CheckoutReturn.tsx — the re-submission path after a failed order creation still relies on backend idempotency enforcement on transaction_id; worth confirming that constraint exists on the backend before merging to production traffic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/ordering/components/CheckoutReturn.tsx | New component that handles Stripe redirect-back and network-failure recovery; queries backend for an existing order before re-submitting to prevent duplicates. |
| src/ordering/utils/pendingCheckout.ts | New sessionStorage-backed draft helper with 4-hour TTL and version field; correctly scoped to the browser tab so 3DS same-tab redirects preserve the draft. |
| src/ordering/components/payment/StripeCheckout.tsx | Migrated from Payment Element to Card Element API; effects correctly sequence Stripe.js load → Elements init (no client secret needed) → card mount (requires clientSecret), fixing the previously flagged blank-card-form bug. |
| src/shared/utils/simpleSpreadsheet.ts | Hand-rolled OOXML/ZIP XLSX generator replacing vulnerable xlsx dependency; correct multi-sheet workbook structure, CRC32, and XML sanitization, but all ZIP entries are stored uncompressed. |
| src/shared/api/endpoints/auth.ts | Fixed stale password-reset paths: POST /password/forgot and PATCH /password/reset with updated field names; no existing callers found in the codebase. |
| src/ordering/components/CheckoutPage.tsx | Saves draft before Stripe payment, clears it on success/error, and redirects to /checkout/return on order-creation failure for Stripe; navigates to /order-confirmation/:id for reload-safety. |
| src/shared/api/endpoints/stripe.ts | Added restaurantId param to getPaymentIntent/confirmPaymentIntent and new findOrderByTransaction helper that treats 404 as no existing order and re-throws other errors. |
| src/ordering/store/orderStore.ts | addOrder now throws on duplicate/error instead of returning a fake error object; adds merchandise_variant_id to payload and precomputes estimated_pickup_time for advance-notice items. |
| src/shared/components/analytics/PostHogProvider.tsx | Fixed conditional hook call (Rules of Hooks violation) by calling useAuthStore/useRestaurantStore unconditionally; disabled session recording to avoid capturing checkout/admin PII. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant CP as CheckoutPage
    participant SC as StripeCheckout
    participant SS as sessionStorage
    participant BE as Backend API
    participant ST as Stripe

    U->>CP: Submit order
    CP->>SS: savePendingCheckoutDraft()
    CP->>SC: processPayment()
    SC->>BE: POST /stripe/create_intent
    BE-->>SC: "{ client_secret }"
    SC->>ST: confirmCardPayment(clientSecret)

    alt Payment succeeds (no 3DS redirect)
        ST-->>SC: "{ paymentIntent.status: succeeded }"
        SC->>CP: onPaymentSuccess(details)
        CP->>BE: POST /orders
        BE-->>CP: newOrder
        CP->>SS: clearPendingCheckoutDraft()
        CP->>U: navigate /order-confirmation/:id
    else 3DS redirect required
        ST-->>U: Redirect to bank 3DS page
        U->>ST: Complete 3DS
        ST-->>U: "Redirect to /checkout/return?payment_intent=..."
        Note over SS: Draft survives same-tab redirect
    else Order creation fails after payment
        BE-->>CP: Error
        CP->>U: "navigate /checkout/return?payment_intent=..."
    end

    rect rgb(240,248,255)
        Note over U,BE: CheckoutReturn recovery flow
        U->>BE: GET /stripe/payment_intent/:id
        BE-->>U: "{ status: succeeded, client_secret }"
        U->>BE: POST /orders/by_transaction (idempotency check)
        alt Order already exists
            BE-->>U: existing order
            U->>SS: clearPendingCheckoutDraft()
            U->>U: navigate /order-confirmation/:id
        else No existing order
            U->>SS: loadPendingCheckoutDraft()
            U->>BE: POST /orders (re-submit)
            BE-->>U: newOrder
            U->>SS: clearPendingCheckoutDraft()
            U->>U: navigate /order-confirmation/:id
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/shared/utils/simpleSpreadsheet.ts:993-1015
**Uncompressed ZIP output produces significantly larger files**

Every entry is written with compression method `0` (stored). The original `xlsx` library used DEFLATE, so report downloads will be noticeably larger — a sheet with thousands of string rows can balloon 5–10× vs. the previous output. `CompressionStream('deflate-raw')` is available in all modern browsers and could be used to add DEFLATE support; it would require changing the compression method field from `0` to `8`, storing the compressed bytes, and updating the local/central directory headers accordingly.

`````

</details>

<sub>Reviews (8): Last reviewed commit: ["Send pickup time for advance-notice chec..."](https://github.com/shimizu-technology/hafaloha_frontend/commit/0e73d62fe4a4a29400df05fe933d6b21d207d7fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35530790)</sub>

<!-- /greptile_comment -->