### PR TITLE
Add automatic Håfaloha paused experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,9 @@
     <link rel="icon" type="image/png" href="/hafaloha-logo-white-bg.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/manifest.json" />
-    <meta name="theme-color" content="#c1902f" />
-    <title>Hafaloha</title>
+    <meta name="theme-color" content="#153c32" />
+    <meta name="description" content="Håfaloha online ordering, reservations, and shop information." />
+    <title>Håfaloha</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "terser": "^5.43.1",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
-        "vite": "^5.4.2"
+        "vite": "^5.4.2",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1217,9 +1218,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -2045,6 +2046,112 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2152,6 +2259,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -2299,6 +2415,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2348,6 +2473,22 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2359,6 +2500,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2726,6 +2876,15 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -2811,6 +2970,12 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -3108,6 +3273,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3121,6 +3295,15 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3763,6 +3946,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3778,6 +3967,15 @@
       "integrity": "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/matchmediaquery": {
@@ -4068,6 +4266,21 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -4751,6 +4964,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4811,6 +5030,18 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -5102,6 +5333,45 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5354,6 +5624,93 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
@@ -5372,6 +5729,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -51,6 +52,7 @@
     "terser": "^5.43.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^2.1.9"
   }
 }

--- a/src/LiveApp.tsx
+++ b/src/LiveApp.tsx
@@ -1,0 +1,56 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { AuthProvider, ScrollToTop, RestaurantProvider } from './shared';
+import PostHogProvider from './shared/components/analytics/PostHogProvider';
+import { ToastContainer } from './shared/components/ToastContainer';
+import { PaymentScriptPreloader } from './shared/components/payment/PaymentScriptPreloader';
+
+import GlobalLayout from './GlobalLayout';
+import ReservationsApp from './reservations/ReservationsApp';
+import OnlineOrderingApp from './ordering/OnlineOrderingApp';
+import WholesaleApp from './wholesale/WholesaleApp';
+
+export default function LiveApp() {
+  return (
+    <AuthProvider>
+      <RestaurantProvider>
+        {/* Preload payment scripts based on restaurant settings */}
+        <PaymentScriptPreloader />
+
+        {/* Keep analytics inside auth and restaurant context */}
+        <PostHogProvider>
+          <BrowserRouter>
+            <ScrollToTop />
+            <ToastContainer
+              position="top-right"
+              reverseOrder={false}
+              containerStyle={{
+                maxHeight: '100vh',
+                overflow: 'auto',
+                paddingRight: '10px',
+                scrollBehavior: 'smooth'
+              }}
+              containerClassName="scrollable-toast-container"
+              gutter={8}
+              toastOptions={{
+                className: '',
+                style: {
+                  maxWidth: '100%',
+                  width: 'auto'
+                },
+                duration: 5000
+              }}
+            />
+
+            <Routes>
+              <Route element={<GlobalLayout />}>
+                <Route path="/reservations/*" element={<ReservationsApp />} />
+                <Route path="/wholesale/*" element={<WholesaleApp />} />
+                <Route path="/*" element={<OnlineOrderingApp />} />
+              </Route>
+            </Routes>
+          </BrowserRouter>
+        </PostHogProvider>
+      </RestaurantProvider>
+    </AuthProvider>
+  );
+}

--- a/src/RootApp.tsx
+++ b/src/RootApp.tsx
@@ -1,66 +1,23 @@
-// src/RootApp.tsx
-import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { AuthProvider, ScrollToTop, RestaurantProvider } from './shared';
-import PostHogProvider from './shared/components/analytics/PostHogProvider';
-import { ToastContainer } from './shared/components/ToastContainer';
-import { PaymentScriptPreloader } from './shared/components/payment/PaymentScriptPreloader';
+import { lazy, Suspense } from 'react';
+import { AvailabilityLoading, ServiceStatusPage } from './components/ServiceStatusPage';
+import { useServiceAvailability } from './hooks/useServiceAvailability';
 
-import GlobalLayout from './GlobalLayout';
-import ReservationsApp from './reservations/ReservationsApp';
-import OnlineOrderingApp from './ordering/OnlineOrderingApp';
-import WholesaleApp from './wholesale/WholesaleApp';
+const LiveApp = lazy(() => import('./LiveApp'));
 
 export default function RootApp() {
+  const { status, retry } = useServiceAvailability();
+
+  if (status === 'checking') {
+    return <AvailabilityLoading />;
+  }
+
+  if (status === 'unavailable') {
+    return <ServiceStatusPage onRetry={() => void retry()} />;
+  }
+
   return (
-    <AuthProvider>
-      <RestaurantProvider>
-        {/* Preload payment scripts based on restaurant settings */}
-        <PaymentScriptPreloader />
-        
-        {/* Move PostHogProvider inside AuthProvider and RestaurantProvider */}
-        <PostHogProvider>
-          <BrowserRouter>
-            <ScrollToTop />
-            <ToastContainer
-              position="top-right"
-              reverseOrder={false}
-              containerStyle={{
-                maxHeight: '100vh',
-                overflow: 'auto',
-                paddingRight: '10px',
-                scrollBehavior: 'smooth'
-              }}
-              containerClassName="scrollable-toast-container"
-              gutter={8}
-              toastOptions={{
-                // Customize for different screen sizes
-                className: '',
-                style: {
-                  maxWidth: '100%',
-                  width: 'auto'
-                },
-                // Default duration of 5 seconds for regular toasts
-                // Order notifications in AdminDashboard will override this with their own duration: Infinity
-                duration: 5000
-              }}
-            />
-
-            <Routes>
-              <Route element={<GlobalLayout />}>
-                {/* Serve Reservations at /reservations/* */}
-                <Route path="/reservations/*" element={<ReservationsApp />} />
-                
-                {/* Serve Wholesale at /wholesale/* */}
-                <Route path="/wholesale/*" element={<WholesaleApp />} />
-
-                {/* Everything else => OnlineOrderingApp at the root */}
-                <Route path="/*" element={<OnlineOrderingApp />} />
-              </Route>
-            </Routes>
-          </BrowserRouter>
-        </PostHogProvider>
-      </RestaurantProvider>
-    </AuthProvider>
+    <Suspense fallback={<AvailabilityLoading />}>
+      <LiveApp />
+    </Suspense>
   );
 }

--- a/src/RootApp.tsx
+++ b/src/RootApp.tsx
@@ -1,8 +1,39 @@
-import { lazy, Suspense } from 'react';
-import { AvailabilityLoading, ServiceStatusPage } from './components/ServiceStatusPage';
+import { Component, lazy, Suspense, type ReactNode } from 'react';
+import {
+  AvailabilityLoading,
+  LiveAppLoadErrorPage,
+  ServiceStatusPage
+} from './components/ServiceStatusPage';
 import { useServiceAvailability } from './hooks/useServiceAvailability';
 
 const LiveApp = lazy(() => import('./LiveApp'));
+
+interface LiveAppErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface LiveAppErrorBoundaryState {
+  hasError: boolean;
+}
+
+class LiveAppErrorBoundary extends Component<
+  LiveAppErrorBoundaryProps,
+  LiveAppErrorBoundaryState
+> {
+  state: LiveAppErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): LiveAppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <LiveAppLoadErrorPage onReload={() => window.location.reload()} />;
+    }
+
+    return this.props.children;
+  }
+}
 
 export default function RootApp() {
   const { status, retry } = useServiceAvailability();
@@ -16,8 +47,10 @@ export default function RootApp() {
   }
 
   return (
-    <Suspense fallback={<AvailabilityLoading />}>
-      <LiveApp />
-    </Suspense>
+    <LiveAppErrorBoundary>
+      <Suspense fallback={<AvailabilityLoading />}>
+        <LiveApp />
+      </Suspense>
+    </LiveAppErrorBoundary>
   );
 }

--- a/src/components/ServiceStatusPage.tsx
+++ b/src/components/ServiceStatusPage.tsx
@@ -1,0 +1,182 @@
+import { useEffect } from 'react';
+import circleLogo from '../ordering/assets/Hafaloha-circle-logo.png';
+import foodCollage from '../ordering/assets/hafaloha_hero.webp';
+
+interface IconProps {
+  className?: string;
+}
+
+function PhoneIcon({ className = 'h-5 w-5' }: IconProps) {
+  return (
+    <svg className={className} aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.8">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106a1.125 1.125 0 0 0-1.173.417l-.97 1.293a1.125 1.125 0 0 1-1.21.38 12.035 12.035 0 0 1-7.143-7.143 1.125 1.125 0 0 1 .38-1.21l1.293-.97c.37-.278.534-.752.417-1.173L6.963 3.102A1.125 1.125 0 0 0 5.872 2.25H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z" />
+    </svg>
+  );
+}
+
+function MapIcon({ className = 'h-5 w-5' }: IconProps) {
+  return (
+    <svg className={className} aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.8">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" />
+    </svg>
+  );
+}
+
+function MailIcon({ className = 'h-5 w-5' }: IconProps) {
+  return (
+    <svg className={className} aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.8">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5A2.25 2.25 0 0 1 19.5 19.5h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0-8.51 5.314a2.25 2.25 0 0 1-2.48 0L2.25 6.75" />
+    </svg>
+  );
+}
+
+function ArrowIcon({ className = 'h-4 w-4' }: IconProps) {
+  return (
+    <svg className={className} aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+      <path strokeLinecap="round" strokeLinejoin="round" d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+export function AvailabilityLoading() {
+  return (
+    <main className="min-h-screen bg-[#f4efe5] text-[#153c32] flex items-center justify-center px-6">
+      <div className="text-center" role="status" aria-live="polite">
+        <div className="mx-auto mb-6 h-24 w-24 rounded-full border border-[#153c32]/10 bg-white p-2 shadow-[0_18px_50px_rgba(21,60,50,0.12)]">
+          <img src={circleLogo} alt="" className="h-full w-full animate-pulse rounded-full object-contain" />
+        </div>
+        <p className="font-display text-4xl text-[#153c32]">håfaloha!</p>
+        <p className="mt-3 text-sm font-semibold uppercase tracking-[0.22em] text-[#153c32]/60">
+          Checking online services
+        </p>
+      </div>
+    </main>
+  );
+}
+
+interface ServiceStatusPageProps {
+  onRetry: () => void;
+}
+
+export function ServiceStatusPage({ onRetry }: ServiceStatusPageProps) {
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = 'Online services paused | Håfaloha';
+
+    return () => {
+      document.title = previousTitle;
+    };
+  }, []);
+
+  return (
+    <main className="min-h-screen overflow-hidden bg-[#f4efe5] text-[#153c32]">
+      <div className="h-2 bg-[linear-gradient(90deg,#eb578c_0_25%,#45c0b5_25%_50%,#ffd84c_50%_75%,#ff7f6a_75%)]" aria-hidden="true" />
+
+      <header className="border-b border-[#153c32]/10 bg-[#f4efe5]/95">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-5 sm:px-8 lg:px-10">
+          <span className="font-display text-3xl tracking-tight text-[#153c32] sm:text-4xl">håfaloha!</span>
+          <a
+            href="tel:+16719893444"
+            className="inline-flex min-h-11 items-center gap-2 rounded-full border border-[#153c32]/20 px-4 text-sm font-semibold transition hover:-translate-y-0.5 hover:border-[#153c32]/40 hover:bg-white focus:outline-none focus:ring-2 focus:ring-[#153c32] focus:ring-offset-2 focus:ring-offset-[#f4efe5]"
+          >
+            <PhoneIcon className="h-4 w-4" />
+            <span className="hidden sm:inline">Call Håfaloha</span>
+            <span className="sm:hidden">Call us</span>
+          </a>
+        </div>
+      </header>
+
+      <section className="mx-auto max-w-6xl px-5 pb-10 pt-8 sm:px-8 sm:pt-12 lg:px-10 lg:pb-16">
+        <div className="overflow-hidden rounded-[1.75rem] border border-[#153c32]/10 bg-[#153c32] shadow-[0_30px_90px_rgba(21,60,50,0.18)] sm:rounded-[2.25rem]">
+          <div className="relative h-36 overflow-hidden sm:h-48 lg:h-56">
+            <img
+              src={foodCollage}
+              alt="A collage of Håfaloha food, shave ice, poke, açaí, and burgers"
+              className="h-full w-full object-cover"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-[#153c32]/45 to-transparent" aria-hidden="true" />
+          </div>
+
+          <div className="grid gap-0 lg:grid-cols-[1.35fr_0.65fr]">
+            <div className="px-6 py-10 text-white sm:px-10 sm:py-14 lg:px-14 lg:py-16">
+              <div className="mb-7 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3.5 py-2 text-xs font-bold uppercase tracking-[0.16em] text-[#ffd84c]">
+                <span className="h-2 w-2 rounded-full bg-[#ffd84c]" aria-hidden="true" />
+                Online services paused
+              </div>
+
+              <h1 className="max-w-3xl text-4xl font-black leading-[1.02] tracking-[-0.04em] sm:text-6xl lg:text-7xl">
+                Ordering is taking a little break.
+              </h1>
+              <p className="mt-6 max-w-2xl text-lg leading-relaxed text-white/80 sm:text-xl">
+                Håfaloha is not taking online orders or reservations through this site right now. For current shop hours, product availability, or anything else, reach the team directly.
+              </p>
+
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                <a
+                  href="tel:+16719893444"
+                  className="group inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-[#ffd84c] px-6 font-bold text-[#153c32] transition hover:-translate-y-0.5 hover:bg-[#ffe47c] focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-[#153c32]"
+                >
+                  <PhoneIcon />
+                  (671) 989-3444
+                  <ArrowIcon className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                </a>
+                <a
+                  href="https://www.google.com/maps/search/?api=1&query=215%20Rojas%20St.%20Unit%20104%20Tamuning%20GU%2096913"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group inline-flex min-h-12 items-center justify-center gap-2 rounded-full border border-white/30 px-6 font-bold text-white transition hover:-translate-y-0.5 hover:border-white/60 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-[#153c32]"
+                >
+                  <MapIcon />
+                  Get directions
+                  <ArrowIcon className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                </a>
+              </div>
+            </div>
+
+            <aside className="border-t border-white/10 bg-[#0d2f27] px-6 py-10 text-white sm:px-10 lg:border-l lg:border-t-0 lg:px-9 lg:py-14">
+              <img
+                src={circleLogo}
+                alt="Håfaloha"
+                className="h-28 w-28 rounded-full object-contain shadow-[0_14px_36px_rgba(0,0,0,0.25)]"
+              />
+
+              <h2 className="mt-8 text-xl font-extrabold tracking-tight">Find the Håfaloha team</h2>
+              <address className="mt-5 not-italic text-[0.98rem] leading-relaxed text-white/72">
+                215 Rojas St., Unit 104<br />
+                Tamuning, Guam 96913
+              </address>
+
+              <a
+                href="mailto:admin@hafaloha.com"
+                className="mt-5 inline-flex items-center gap-2 font-semibold text-white underline decoration-white/30 underline-offset-4 transition hover:decoration-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-4 focus:ring-offset-[#0d2f27]"
+              >
+                <MailIcon />
+                admin@hafaloha.com
+              </a>
+
+              <div className="mt-9 border-t border-white/10 pt-7">
+                <p className="text-sm leading-relaxed text-white/60">
+                  Think the ordering system is back online?
+                </p>
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  className="group mt-3 inline-flex min-h-11 items-center gap-2 rounded-full border border-white/25 px-4 text-sm font-bold text-white transition hover:border-white/50 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-[#0d2f27]"
+                >
+                  Check again
+                  <ArrowIcon className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                </button>
+              </div>
+            </aside>
+          </div>
+        </div>
+
+        <footer className="flex flex-col gap-3 px-1 pt-7 text-sm text-[#153c32]/60 sm:flex-row sm:items-center sm:justify-between">
+          <p>© {new Date().getFullYear()} Håfaloha. All rights reserved.</p>
+          <p>Guam-grown goods, food, and island flavor.</p>
+        </footer>
+      </section>
+    </main>
+  );
+}

--- a/src/components/ServiceStatusPage.tsx
+++ b/src/components/ServiceStatusPage.tsx
@@ -55,6 +55,61 @@ export function AvailabilityLoading() {
   );
 }
 
+interface LiveAppLoadErrorPageProps {
+  onReload: () => void;
+}
+
+export function LiveAppLoadErrorPage({ onReload }: LiveAppLoadErrorPageProps) {
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = 'Reload ordering | Håfaloha';
+
+    return () => {
+      document.title = previousTitle;
+    };
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-[#f4efe5] px-6 py-12 text-[#153c32] sm:py-20">
+      <div className="mx-auto max-w-xl overflow-hidden rounded-[2rem] border border-[#153c32]/10 bg-white shadow-[0_30px_90px_rgba(21,60,50,0.15)]">
+        <div className="h-2 bg-[linear-gradient(90deg,#eb578c_0_25%,#45c0b5_25%_50%,#ffd84c_50%_75%,#ff7f6a_75%)]" aria-hidden="true" />
+        <div className="px-7 py-10 text-center sm:px-12 sm:py-14">
+          <img
+            src={circleLogo}
+            alt="Håfaloha"
+            className="mx-auto h-24 w-24 rounded-full object-contain shadow-[0_14px_36px_rgba(21,60,50,0.15)]"
+          />
+          <p className="mt-7 text-xs font-bold uppercase tracking-[0.2em] text-[#153c32]/55">
+            Connection interrupted
+          </p>
+          <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] sm:text-4xl">
+            The ordering page didn&apos;t finish loading.
+          </h1>
+          <p className="mx-auto mt-4 max-w-md leading-relaxed text-[#153c32]/70">
+            Refresh the page to try loading it again. If the problem continues, call Håfaloha and the team will be happy to help.
+          </p>
+          <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
+            <button
+              type="button"
+              onClick={onReload}
+              className="inline-flex min-h-12 items-center justify-center rounded-full bg-[#153c32] px-6 font-bold text-white transition hover:-translate-y-0.5 hover:bg-[#0d2f27] focus:outline-none focus:ring-2 focus:ring-[#153c32] focus:ring-offset-2"
+            >
+              Reload ordering
+            </button>
+            <a
+              href="tel:+16719893444"
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full border border-[#153c32]/20 px-6 font-bold transition hover:-translate-y-0.5 hover:border-[#153c32]/40 focus:outline-none focus:ring-2 focus:ring-[#153c32] focus:ring-offset-2"
+            >
+              <PhoneIcon />
+              (671) 989-3444
+            </a>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
 interface ServiceStatusPageProps {
   onRetry: () => void;
 }

--- a/src/hooks/useServiceAvailability.ts
+++ b/src/hooks/useServiceAvailability.ts
@@ -24,14 +24,19 @@ export function useServiceAvailability() {
   useEffect(() => {
     void retry();
 
-    const handleOnline = () => void retry();
-    window.addEventListener('online', handleOnline);
-
     return () => {
-      window.removeEventListener('online', handleOnline);
       activeCheck.current?.abort();
     };
   }, [retry]);
+
+  useEffect(() => {
+    if (status !== 'unavailable') return;
+
+    const handleOnline = () => void retry();
+    window.addEventListener('online', handleOnline);
+
+    return () => window.removeEventListener('online', handleOnline);
+  }, [retry, status]);
 
   return { status, retry };
 }

--- a/src/hooks/useServiceAvailability.ts
+++ b/src/hooks/useServiceAvailability.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { checkServiceAvailability } from '../serviceAvailability';
+
+export type ServiceAvailability = 'checking' | 'available' | 'unavailable';
+
+export function useServiceAvailability() {
+  const [status, setStatus] = useState<ServiceAvailability>('checking');
+  const activeCheck = useRef<AbortController | null>(null);
+
+  const retry = useCallback(async () => {
+    activeCheck.current?.abort();
+
+    const controller = new AbortController();
+    activeCheck.current = controller;
+    setStatus('checking');
+
+    const isAvailable = await checkServiceAvailability({ signal: controller.signal });
+
+    if (!controller.signal.aborted) {
+      setStatus(isAvailable ? 'available' : 'unavailable');
+    }
+  }, []);
+
+  useEffect(() => {
+    void retry();
+
+    const handleOnline = () => void retry();
+    window.addEventListener('online', handleOnline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      activeCheck.current?.abort();
+    };
+  }, [retry]);
+
+  return { status, retry };
+}

--- a/src/serviceAvailability.test.ts
+++ b/src/serviceAvailability.test.ts
@@ -62,4 +62,19 @@ describe('checkServiceAvailability', () => {
       timeoutMs: 5
     })).resolves.toBe(false);
   });
+
+  it('does not start a request when the caller signal is already aborted', async () => {
+    const controller = new AbortController();
+    const fetchImpl = vi.fn(async () => jsonResponse({ status: 'available', restaurant_id: 7 }));
+    controller.abort();
+
+    await expect(checkServiceAvailability({
+      apiBaseUrl: 'https://api.example.com',
+      restaurantId: '7',
+      fetchImpl,
+      signal: controller.signal
+    })).resolves.toBe(false);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });

--- a/src/serviceAvailability.test.ts
+++ b/src/serviceAvailability.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildFrontendHealthUrl, checkServiceAvailability } from './serviceAvailability';
+
+const jsonResponse = (body: unknown, status = 200) => new Response(JSON.stringify(body), {
+  status,
+  headers: { 'Content-Type': 'application/json' }
+});
+
+describe('buildFrontendHealthUrl', () => {
+  it('builds the tenant-specific readiness URL with or without a trailing slash', () => {
+    expect(buildFrontendHealthUrl('https://api.example.com', '7')).toBe(
+      'https://api.example.com/health/frontend?restaurant_id=7'
+    );
+    expect(buildFrontendHealthUrl('https://api.example.com/', '7')).toBe(
+      'https://api.example.com/health/frontend?restaurant_id=7'
+    );
+  });
+});
+
+describe('checkServiceAvailability', () => {
+  it('returns true only for the expected restaurant readiness contract', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ status: 'available', restaurant_id: 7 }));
+
+    await expect(checkServiceAvailability({
+      apiBaseUrl: 'https://api.example.com',
+      restaurantId: '7',
+      fetchImpl
+    })).resolves.toBe(true);
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.example.com/health/frontend?restaurant_id=7',
+      expect.objectContaining({
+        method: 'GET',
+        cache: 'no-store',
+        signal: expect.any(AbortSignal)
+      })
+    );
+  });
+
+  it.each([
+    ['an error response', async () => jsonResponse({ errors: ['Unavailable'] }, 503)],
+    ['an unexpected status', async () => jsonResponse({ status: 'ok', restaurant_id: 7 })],
+    ['a different restaurant', async () => jsonResponse({ status: 'available', restaurant_id: 8 })],
+    ['a network failure', async () => { throw new TypeError('Failed to fetch'); }]
+  ])('returns false for %s', async (_description, fetchImpl) => {
+    await expect(checkServiceAvailability({
+      apiBaseUrl: 'https://api.example.com',
+      restaurantId: '7',
+      fetchImpl
+    })).resolves.toBe(false);
+  });
+
+  it('returns false when the readiness request times out', async () => {
+    const fetchImpl = vi.fn((_url: URL | RequestInfo, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+    }));
+
+    await expect(checkServiceAvailability({
+      apiBaseUrl: 'https://api.example.com',
+      restaurantId: '7',
+      fetchImpl,
+      timeoutMs: 5
+    })).resolves.toBe(false);
+  });
+});

--- a/src/serviceAvailability.ts
+++ b/src/serviceAvailability.ts
@@ -32,6 +32,8 @@ export async function checkServiceAvailability({
   signal,
   timeoutMs = DEFAULT_TIMEOUT_MS
 }: CheckServiceAvailabilityOptions = {}): Promise<boolean> {
+  if (signal?.aborted) return false;
+
   const controller = new AbortController();
   const abortCheck = () => controller.abort();
   const timeout = globalThis.setTimeout(abortCheck, timeoutMs);

--- a/src/serviceAvailability.ts
+++ b/src/serviceAvailability.ts
@@ -1,0 +1,59 @@
+import { config } from './shared/config';
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+interface AvailabilityResponse {
+  status?: unknown;
+  restaurant_id?: unknown;
+}
+
+interface CheckServiceAvailabilityOptions {
+  apiBaseUrl?: string;
+  restaurantId?: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export function buildFrontendHealthUrl(
+  apiBaseUrl = config.apiBaseUrl,
+  restaurantId = config.restaurantId
+): string {
+  const baseUrl = apiBaseUrl.endsWith('/') ? apiBaseUrl : `${apiBaseUrl}/`;
+  const url = new URL('health/frontend', baseUrl);
+  url.searchParams.set('restaurant_id', restaurantId);
+  return url.toString();
+}
+
+export async function checkServiceAvailability({
+  apiBaseUrl = config.apiBaseUrl,
+  restaurantId = config.restaurantId,
+  fetchImpl = fetch,
+  signal,
+  timeoutMs = DEFAULT_TIMEOUT_MS
+}: CheckServiceAvailabilityOptions = {}): Promise<boolean> {
+  const controller = new AbortController();
+  const abortCheck = () => controller.abort();
+  const timeout = globalThis.setTimeout(abortCheck, timeoutMs);
+
+  signal?.addEventListener('abort', abortCheck, { once: true });
+
+  try {
+    const response = await fetchImpl(buildFrontendHealthUrl(apiBaseUrl, restaurantId), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+      signal: controller.signal
+    });
+
+    if (!response.ok) return false;
+
+    const body = await response.json() as AvailabilityResponse;
+    return body.status === 'available' && String(body.restaurant_id) === restaurantId;
+  } catch {
+    return false;
+  } finally {
+    globalThis.clearTimeout(timeout);
+    signal?.removeEventListener('abort', abortCheck);
+  }
+}


### PR DESCRIPTION
## Summary

- check the configured backend automatically at runtime; no service-mode environment variable is required
- keep auth, tenant polling, payment scripts, analytics, WebSockets, and live routes unmounted while the backend is unavailable
- show a branded, responsive Håfaloha paused experience with direct call, email, directions, and retry paths
- lazy-load the unchanged live application after the backend readiness contract succeeds
- add focused unit coverage for URL construction, tenant matching, HTTP failures, network failures, and timeouts

## Deployment order

Merge and deploy [shimizu-order-suite#103](https://github.com/Shimizu-Technology/shimizu-order-suite/pull/103) first. If this frontend deploys before the backend endpoint, it will intentionally remain in the safe paused state until the endpoint is available and the visitor retries or reloads.

Once both are deployed and the paused state has been verified on `hafaloha-orders.com`, the legacy Render web service, background worker, and Redis instance can be suspended. The static Netlify frontend remains online.

## Verification

- `npm test` — 7 tests passing
- `npm run build` — production build succeeds
- focused ESLint pass on all six new/changed source files
- desktop and 390px mobile browser QA of the paused experience
- verified unavailable retry behavior and successful handoff to the existing live app with a controlled readiness response

## Baseline notes

- the repository-wide lint command continues to report pre-existing legacy issues outside this change
- the existing production dependency audit and CSS interpolation warning are unchanged by this feature

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a runtime backend-readiness gate that keeps the full React application (auth, analytics, WebSockets, payment scripts) unmounted until the new `/health/frontend` endpoint confirms the backend is available. When unavailable, a branded "paused" page is shown with direct contact and retry paths.

- `serviceAvailability.ts` implements a typed health-check with a configurable timeout, external-abort forwarding, and a strict `{ status, restaurant_id }` contract — all three previously flagged edge cases (pre-aborted signal, error boundary, mid-session `online` retry) have been addressed.
- `LiveApp.tsx` is the existing live application extracted verbatim and lazy-loaded only after the readiness contract passes; `RootApp.tsx` now acts as a thin orchestrator with a `LiveAppErrorBoundary` that surfaces chunk-load failures with a reload path.
- `ServiceStatusPage.tsx` delivers the paused UX; `serviceAvailability.test.ts` adds focused unit coverage for URL construction, HTTP variants, network failures, timeouts, and abort semantics.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive, the full live application is still rendered on the happy path, and all three previously flagged behavioral concerns have been corrected in this revision.

The availability check, abort handling, timeout, and error boundary logic are all sound. The `online` event handler is correctly scoped to the `unavailable` state, the pre-aborted signal early return is present and tested, and the `LiveAppErrorBoundary` wraps the lazy import. Unit tests cover the meaningful failure modes of the core utility. The only open item is the absence of error logging in the error boundary, which does not affect correctness.

No files require special attention. The most complex logic lives in `src/serviceAvailability.ts` and `src/hooks/useServiceAvailability.ts`, both of which are clean.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/serviceAvailability.ts | Core health-check utility; correctly handles timeout, external abort, pre-aborted signal early return, and JSON contract validation. |
| src/hooks/useServiceAvailability.ts | Hook managing check lifecycle; `online` listener is correctly guarded to only activate when `status === 'unavailable'`, preventing mid-session disruption. |
| src/RootApp.tsx | Orchestration layer with `LiveAppErrorBoundary` wrapping the lazy `LiveApp`; all three previously flagged concerns (error boundary, pre-aborted signal, online retry) are now addressed. |
| src/components/ServiceStatusPage.tsx | Branded paused-state page with `AvailabilityLoading`, `LiveAppLoadErrorPage`, and `ServiceStatusPage` exports; good accessibility attributes and responsive layout. |
| src/LiveApp.tsx | Content extracted verbatim from the previous `RootApp.tsx`; now lazily loaded after the backend readiness check passes. |
| src/serviceAvailability.test.ts | Good focused unit coverage: URL construction, successful contract validation, HTTP error variants, network failure, timeout, and pre-aborted signal. |
| index.html | Updated theme-color, corrected title to include diacritic, and added `description` meta tag. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant B as Browser
    participant R as RootApp
    participant H as useServiceAvailability
    participant A as checkServiceAvailability
    participant API as Backend /health/frontend

    B->>R: Mount
    R->>H: useServiceAvailability()
    H-->>R: "status = 'checking'"
    R-->>B: Render AvailabilityLoading

    H->>A: "checkServiceAvailability({ signal })"
    Note over A: 8 s timeout + external abort wired
    A->>API: "GET /health/frontend?restaurant_id=N"
    alt Backend available
        API-->>A: "200 { status: "available", restaurant_id: N }"
        A-->>H: true
        H-->>R: "status = 'available'"
        R-->>B: "Render LiveAppErrorBoundary > Suspense > lazy LiveApp"
    else Backend unavailable / timeout / network error
        API-->>A: 503 / timeout / throws
        A-->>H: false
        H-->>R: "status = 'unavailable'"
        R-->>B: Render ServiceStatusPage
        B->>R: User clicks "Check again" (onRetry)
        R->>H: retry()
        H->>A: checkServiceAvailability (new AbortController)
        A->>API: "GET /health/frontend?restaurant_id=N"
    end

    opt Browser comes back online while unavailable
        B->>H: "window 'online' event (only when status==='unavailable')"
        H->>A: retry()
    end

    opt LiveApp chunk fails to load
        B-->>R: LiveAppErrorBoundary catches error
        R-->>B: Render LiveAppLoadErrorPage + Reload ordering
        B->>B: window.location.reload()
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant B as Browser
    participant R as RootApp
    participant H as useServiceAvailability
    participant A as checkServiceAvailability
    participant API as Backend /health/frontend

    B->>R: Mount
    R->>H: useServiceAvailability()
    H-->>R: "status = 'checking'"
    R-->>B: Render AvailabilityLoading

    H->>A: "checkServiceAvailability({ signal })"
    Note over A: 8 s timeout + external abort wired
    A->>API: "GET /health/frontend?restaurant_id=N"
    alt Backend available
        API-->>A: "200 { status: "available", restaurant_id: N }"
        A-->>H: true
        H-->>R: "status = 'available'"
        R-->>B: "Render LiveAppErrorBoundary > Suspense > lazy LiveApp"
    else Backend unavailable / timeout / network error
        API-->>A: 503 / timeout / throws
        A-->>H: false
        H-->>R: "status = 'unavailable'"
        R-->>B: Render ServiceStatusPage
        B->>R: User clicks "Check again" (onRetry)
        R->>H: retry()
        H->>A: checkServiceAvailability (new AbortController)
        A->>API: "GET /health/frontend?restaurant_id=N"
    end

    opt Browser comes back online while unavailable
        B->>H: "window 'online' event (only when status==='unavailable')"
        H->>A: retry()
    end

    opt LiveApp chunk fails to load
        B-->>R: LiveAppErrorBoundary catches error
        R-->>B: Render LiveAppLoadErrorPage + Reload ordering
        B->>B: window.location.reload()
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Harden paused-state recovery"](https://github.com/shimizu-technology/hafaloha_frontend/commit/e12a3e3b44e9e9ff153e6ffaa3a655b403697caf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45556573)</sub>

<!-- /greptile_comment -->